### PR TITLE
MODINVOSTO-6 - Implement invoice-number API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -65,6 +65,17 @@
       ]
     },
     {
+      "id": "invoice-storage.invoice-number",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/invoice-storage/invoice-number",
+          "permissionsRequired": ["invoice-storage.invoice-number.get"]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "1.2",
       "interfaceType": "system",
@@ -128,6 +139,11 @@
       "description": "Delete invoice line"
     },
     {
+      "permissionName" : "invoice-storage.invoice-number.get",
+      "displayName" : "Invoice storage - generate invoice number",
+      "description" : "Get invoice number"
+    },
+    {
       "permissionName": "invoice-storage.module.all",
       "displayName": "Invoice storage module - all permissions",
       "description": "Entire set of permissions needed to use the invoice module",
@@ -141,7 +157,8 @@
         "invoice-storage.invoice-lines.item.get",
         "invoice-storage.invoice-lines.item.post",
         "invoice-storage.invoice-lines.item.put",
-        "invoice-storage.invoice-lines.item.delete"
+        "invoice-storage.invoice-lines.item.delete",
+        "invoice-storage.invoice-number.get"
       ],
       "visible": false
     }

--- a/ramls/invoice-number.raml
+++ b/ramls/invoice-number.raml
@@ -1,0 +1,35 @@
+#%RAML 1.0
+title: "Invoice Storage"
+baseUri: http://github.com/folio-org/mod-invoice-storage
+version: v2
+
+documentation:
+  - title: Invoice Number
+    content: <b>API used to manage invoice number.</b>
+
+types:
+  sequenceNumber: !include acq-models/common/schemas/sequence_number.json
+
+traits:
+    language: !include raml-util/traits/language.raml
+
+/invoice-storage/invoice-number:
+    get:
+      is: [language]
+      description: Get generated invoice number
+      responses:
+        200:
+          body:
+            application/json:
+              type: sequenceNumber
+        400:
+          description: "Bad request, e.g. malformed request body or query parameter"
+          body:
+            text/plain:
+              example: "Unable to generate invoice number"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "internal server error, contact administrator"
+

--- a/ramls/invoice-number.raml
+++ b/ramls/invoice-number.raml
@@ -22,11 +22,6 @@ traits:
           body:
             application/json:
               type: sequenceNumber
-        400:
-          description: "Bad request, e.g. malformed request body or query parameter"
-          body:
-            text/plain:
-              example: "Unable to generate invoice number"
         500:
           description: "Internal server error, e.g. due to misconfiguration"
           body:

--- a/ramls/invoice-number.raml
+++ b/ramls/invoice-number.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Invoice Storage"
 baseUri: http://github.com/folio-org/mod-invoice-storage
-version: v2
+version: v1
 
 documentation:
   - title: Invoice Number

--- a/ramls/invoice.raml
+++ b/ramls/invoice.raml
@@ -81,25 +81,6 @@ resourceTypes:
       put:
         is: [validate]
 
-  /invoice-number:
-    get:
-      is: [language]
-      description: Get generated invoice number
-      responses:
-        200:
-          body:
-            application/json:
-              type: sequenceNumber
-        400:
-          description: "Bad request, e.g. malformed request body or query parameter"
-          body:
-            text/plain:
-              example: "Unable to generate invoice number"
-        500:
-          description: "Internal server error, e.g. due to misconfiguration"
-          body:
-            text/plain:
-              example: "internal server error, contact administrator"
   /invoice-line-number:
     get:
       is: [language]

--- a/src/main/java/org/folio/rest/impl/InvoiceNumberImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceNumberImpl.java
@@ -1,0 +1,56 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.SequenceNumber;
+import org.folio.rest.jaxrs.resource.InvoiceStorageInvoiceNumber;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.messages.MessageConsts;
+import org.folio.rest.tools.messages.Messages;
+import org.folio.rest.tools.utils.TenantTool;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.jaxrs.resource.InvoiceStorageInvoiceNumber.GetInvoiceStorageInvoiceNumberResponse.*;
+
+public class InvoiceNumberImpl implements InvoiceStorageInvoiceNumber {
+
+  private final Messages messages = Messages.getInstance();
+
+  private static final Logger log = LoggerFactory.getLogger(InvoiceNumberImpl.class);
+  private static final String INVOICE_NUMBER_QUERY = "SELECT nextval('invoice_number')";
+
+  @Override
+  public void getInvoiceStorageInvoiceNumber(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext((Void v) -> {
+      try {
+        String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+        PostgresClient.getInstance(vertxContext.owner(), tenantId).select(INVOICE_NUMBER_QUERY, reply -> {
+          try {
+            if (reply.succeeded()) {
+              String invoiceNumber = reply.result().getResults().get(0).getList().get(0).toString();
+              asyncResultHandler.handle(succeededFuture(respond200WithApplicationJson(new SequenceNumber().withSequenceNumber(invoiceNumber))));
+            } else {
+              Throwable cause = reply.cause();
+              log.error(cause.getMessage(), cause);
+              asyncResultHandler.handle(succeededFuture(respond400WithTextPlain(cause.getMessage())));
+            }
+          } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            asyncResultHandler.handle(succeededFuture(respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
+          }
+        });
+      } catch (Exception e) {
+        log.error(e.getMessage(), e);
+        String message = messages.getMessage(lang, MessageConsts.InternalServerError);
+        asyncResultHandler.handle(succeededFuture(respond500WithTextPlain(message)));
+      }
+    });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InvoiceNumberImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceNumberImpl.java
@@ -34,7 +34,7 @@ public class InvoiceNumberImpl implements InvoiceStorageInvoiceNumber {
         if (reply.succeeded()) {
           try {
             String invoiceNumber = reply.result().getList().get(0).toString();
-            log.debug("Retrieved invoice number: " + invoiceNumber);
+            log.debug("Retrieved invoice number: {}", invoiceNumber);
             asyncResultHandler.handle(succeededFuture(respond200WithApplicationJson(new SequenceNumber().withSequenceNumber(invoiceNumber))));
           } catch(Exception e) {
             log.error(e.getMessage(), e);

--- a/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.persist.HelperUtils.getEntitiesCollection;
 import static org.folio.rest.persist.HelperUtils.SequenceQuery.CREATE_SEQUENCE;
 import static org.folio.rest.persist.HelperUtils.SequenceQuery.DROP_SEQUENCE;
@@ -40,14 +39,13 @@ private static final String INVOICE_PREFIX = "/invoice-storage/invoices/";
 
 private PostgresClient pgClient;
 
-private String idFieldName = "id";
 public static final String INVOICE_TABLE = "invoices";
 private static final String INVOICE_LINE_TABLE = "invoice_lines";
 private static final String ID_FIELD_NAME = "id";
 
   public InvoiceStorageImpl(Vertx vertx, String tenantId) {
     pgClient = PostgresClient.getInstance(vertx, tenantId);
-    pgClient.setIdField(idFieldName);
+    pgClient.setIdField(ID_FIELD_NAME);
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
@@ -25,8 +25,8 @@ import io.vertx.core.Vertx;
 
 public class InvoiceStorageImpl implements InvoiceStorage {
 
-private static final String INVOICE_TABLE = "invoice";
-private static final String INVOICE_LINE_TABLE = "invoice_line";
+private static final String INVOICE_TABLE = "invoices";
+private static final String INVOICE_LINE_TABLE = "invoice_lines";
 private static final String ID_FIELD_NAME = "id";
 
   public InvoiceStorageImpl(Vertx vertx, String tenantId) {
@@ -99,11 +99,6 @@ private static final String ID_FIELD_NAME = "id";
   @Override
   public void deleteInvoiceStorageInvoiceLinesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.deleteById(INVOICE_LINE_TABLE, id, okapiHeaders, vertxContext, DeleteInvoiceStorageInvoiceLinesByIdResponse.class, asyncResultHandler);
-  }
-
-  @Override
-  public void getInvoiceStorageInvoiceNumber(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(succeededFuture(Response.status(501).build()));
   }
 
   @Override

--- a/src/main/resources/templates/db_scripts/invoice_number_sequence.sql
+++ b/src/main/resources/templates/db_scripts/invoice_number_sequence.sql
@@ -1,0 +1,3 @@
+CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.invoice_number NO MAXVALUE START WITH 10000 CACHE 1 NO CYCLE;
+GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.invoice_number TO ${myuniversity}_${mymodule};
+CREATE UNIQUE INDEX IF NOT EXISTS invoices_invoice_number_unique_idx ON ${myuniversity}_${mymodule}.invoices ((jsonb->>'invoiceNumber'));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,14 +1,15 @@
 {
   "tables": [
     {
-      "tableName": "invoice",
+      "tableName": "invoices",
       "generateId": true,
       "fromModuleVersion": 1.0,
       "withMetadata": true,
-      "populateJsonWithId": true
+      "populateJsonWithId": true,
+      "customSnippetPath": "invoice_number_sequence.sql"
     },
     {
-      "tableName": "invoice_line",
+      "tableName": "invoice_lines",
       "generateId": true,
       "fromModuleVersion": 1.0,
       "withMetadata": true,

--- a/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
@@ -1,22 +1,43 @@
 package org.folio.rest.impl;
 
+import io.vertx.ext.unit.junit.Repeat;
+import io.vertx.ext.unit.junit.RepeatRule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class InvoiceNumberTest extends TestBase {
 
+  @Rule
+  public RepeatRule rule = new RepeatRule();
+  private static List<Long> invoiceNumberList;
+
   private static final String SEQUENCE_NUMBER = "sequenceNumber";
   private static final String INVOICE_NUMBER_ENDPOINT = "/invoice-storage/invoice-number";
 
+  @BeforeClass
+  public static void setUp() {
+    invoiceNumberList  = new ArrayList<>();
+  }
+
   @Test
+  @Repeat(3)
   public void testGetInvoiceNumber() throws MalformedURLException {
-    long[] invoiceNumbers = new long[]{getNumberAsLong(), getNumberAsLong(), getNumberAsLong()};
-    assertThat(invoiceNumbers[1] - invoiceNumbers[0], equalTo(1L));
-    assertThat(invoiceNumbers[2] - invoiceNumbers[0], equalTo(2L));
+    invoiceNumberList.add(getNumberAsLong());
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    assertThat(invoiceNumberList.get(1) - invoiceNumberList.get(0), equalTo(1L));
+    assertThat(invoiceNumberList.get(2) - invoiceNumberList.get(0), equalTo(2L));
   }
 
   private long getNumberAsLong() throws MalformedURLException {

--- a/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
@@ -7,7 +7,7 @@ import java.net.MalformedURLException;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-public class NumbersTest extends TestBase {
+public class InvoiceNumberTest extends TestBase {
 
   private static final String SEQUENCE_NUMBER = "sequenceNumber";
   private static final String INVOICE_NUMBER_ENDPOINT = "/invoice-storage/invoice-number";

--- a/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
@@ -1,7 +1,12 @@
 package org.folio.rest.impl;
 
+import io.restassured.http.ContentType;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.UpdateResult;
 import io.vertx.ext.unit.junit.Repeat;
 import io.vertx.ext.unit.junit.RepeatRule;
+import org.folio.HttpStatus;
+import org.folio.rest.persist.PostgresClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -10,7 +15,12 @@ import org.junit.Test;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
+import static io.restassured.RestAssured.given;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.rest.impl.StorageTestSuite.storageUrl;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -22,6 +32,7 @@ public class InvoiceNumberTest extends TestBase {
 
   private static final String SEQUENCE_NUMBER = "sequenceNumber";
   private static final String INVOICE_NUMBER_ENDPOINT = "/invoice-storage/invoice-number";
+  private static final String DROP_SEQUENCE_QUERY = "DROP SEQUENCE diku_mod_invoice_storage.invoice_number";
 
   @BeforeClass
   public static void setUp() {
@@ -35,17 +46,45 @@ public class InvoiceNumberTest extends TestBase {
   }
 
   @AfterClass
-  public static void tearDown() {
+  public static void tearDown() throws Exception {
     assertThat(invoiceNumberList.get(1) - invoiceNumberList.get(0), equalTo(1L));
     assertThat(invoiceNumberList.get(2) - invoiceNumberList.get(0), equalTo(2L));
+
+    // Negative scenario - retrieving number from non-existed sequence
+    dropSequenceInDb();
+    testProcessingErrorReply();
   }
 
   private long getNumberAsLong() throws MalformedURLException {
     return new Long(getData(INVOICE_NUMBER_ENDPOINT)
       .then()
-        .statusCode(200)
+        .statusCode(HttpStatus.HTTP_OK.toInt())
         .extract()
           .response()
             .path(SEQUENCE_NUMBER));
+  }
+
+  private static void testProcessingErrorReply() throws MalformedURLException {
+    given()
+      .header(TENANT_HEADER)
+      .contentType(ContentType.JSON)
+        .get(storageUrl(INVOICE_NUMBER_ENDPOINT))
+          .then()
+            .statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt())
+            .contentType(TEXT_PLAIN)
+            .extract()
+              .response();
+  }
+
+  private static void dropSequenceInDb() throws Exception {
+    CompletableFuture<UpdateResult> future = new CompletableFuture<>();
+      PostgresClient.getInstance(Vertx.vertx()).execute(DROP_SEQUENCE_QUERY, result -> {
+        if(result.failed()) {
+          future.completeExceptionally(result.cause());
+        } else {
+          future.complete(result.result());
+        }
+      });
+      future.get(10, TimeUnit.SECONDS);
   }
 }

--- a/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceNumberTest.java
@@ -70,7 +70,7 @@ public class InvoiceNumberTest extends TestBase {
       .contentType(ContentType.JSON)
         .get(storageUrl(INVOICE_NUMBER_ENDPOINT))
           .then()
-            .statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt())
+            .statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
             .contentType(TEXT_PLAIN)
             .extract()
               .response();

--- a/src/test/java/org/folio/rest/impl/NumbersTest.java
+++ b/src/test/java/org/folio/rest/impl/NumbersTest.java
@@ -1,0 +1,30 @@
+package org.folio.rest.impl;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class NumbersTest extends TestBase {
+
+  private static final String SEQUENCE_NUMBER = "sequenceNumber";
+  private static final String INVOICE_NUMBER_ENDPOINT = "/invoice-storage/invoice-number";
+
+  @Test
+  public void testGetInvoiceNumber() throws MalformedURLException {
+    long[] invoiceNumbers = new long[]{getNumberAsLong(), getNumberAsLong(), getNumberAsLong()};
+    assertThat(invoiceNumbers[1] - invoiceNumbers[0], equalTo(1L));
+    assertThat(invoiceNumbers[2] - invoiceNumbers[0], equalTo(2L));
+  }
+
+  private long getNumberAsLong() throws MalformedURLException {
+    return new Long(getData(INVOICE_NUMBER_ENDPOINT)
+      .then()
+        .statusCode(200)
+        .extract()
+          .response()
+            .path(SEQUENCE_NUMBER));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -33,7 +33,8 @@ import static org.folio.rest.impl.TestBase.TENANT_HEADER;
 @RunWith(Suite.class)
 
 @Suite.SuiteClasses({
-  CrudTest.class
+  CrudTest.class,
+  InvoiceNumberTest.class
 })
 
 public class StorageTestSuite {


### PR DESCRIPTION
[MODINVOSTO-6](https://issues.folio.org/browse/MODINVOSTO-6) - Implement invoice-number API

## Purpose
Implementation of invoice-number API - GET /invoice-storage/invoice-number

## Approach
- ModuleDescriptor-template.json updated;
- invoice-number.raml to separate invoice CRUD operations from invoice number generation;
- invoice_number_sequence.sql created for PostgeSQL sequence;
- unit tests created.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.