### PR TITLE
MODINVOSTO-24 Schema updates: add billTo and exportToAccounting properties

### DIFF
--- a/src/main/resources/data/invoice-lines/30121-1.json
+++ b/src/main/resources/data/invoice-lines/30121-1.json
@@ -1,8 +1,15 @@
 {
   "id": "9b0b32e3-ef48-4bb8-91a5-750a850cc63c",
   "adjustments": [
+    {
+      "description": "Discount",
+      "type": "Amount",
+      "value": -200.00,
+      "prorate":"Not prorated",
+      "relationToTotal":"In addition to"
+    }
   ],
-  "adjustmentsTotal": 0.00,
+  "adjustmentsTotal": -200.00,
   "description": "With shipping",
   "fundDistributions": [
     {
@@ -21,5 +28,5 @@
   "quantity": 1,
   "releaseEncumbrance": false,
   "subTotal": 200000.00,
-  "total": 200000.00
+  "total": 199800.00
 }

--- a/src/main/resources/data/invoices/10411_paid.json
+++ b/src/main/resources/data/invoices/10411_paid.json
@@ -6,6 +6,7 @@
   "approvedBy": "b72a28f6-04fc-489f-be18-ad53a3a64f67",
   "approvalDate": "2014-07-15T09:00:00Z",
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "10411",
   "invoiceDate": "2014-07-14T00:00:00Z",
   "paymentTerms": "Payment in Advance",

--- a/src/main/resources/data/invoices/12345_paid.json
+++ b/src/main/resources/data/invoices/12345_paid.json
@@ -20,6 +20,7 @@
   "approvedBy": "b72a28f6-04fc-489f-be18-ad53a3a64f67",
   "approvalDate": "2019-05-20T00:00:00Z",
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "12345",
   "invoiceDate": "2019-05-18T00:00:00Z",
   "note": "Some note",

--- a/src/main/resources/data/invoices/123invoicenumber45_approved_for_2_orders.json
+++ b/src/main/resources/data/invoices/123invoicenumber45_approved_for_2_orders.json
@@ -5,6 +5,7 @@
   ],
   "adjustmentsTotal": 50.00,
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "123invoicenumber45",
   "invoiceDate": "2018-07-25T00:00:00.000+0000",
   "note": "Some note",

--- a/src/main/resources/data/invoices/123invoicenumber57_reviewed.json
+++ b/src/main/resources/data/invoices/123invoicenumber57_reviewed.json
@@ -4,6 +4,7 @@
   ],
   "adjustmentsTotal":100.00,
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "123invoicenumber57",
   "invoiceDate": "2018-07-27T00:00:00.000+0000",
   "paymentMethod": "EFT",

--- a/src/main/resources/data/invoices/19284_paid.json
+++ b/src/main/resources/data/invoices/19284_paid.json
@@ -6,6 +6,7 @@
   "approvedBy": "b72a28f6-04fc-489f-be18-ad53a3a64f67",
   "approvalDate": "2018-07-50T00:00:00Z",
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "19284",
   "invoiceDate": "2018-07-01T00:00:00Z",
   "paymentMethod": "EFT",

--- a/src/main/resources/data/invoices/30121_paid.json
+++ b/src/main/resources/data/invoices/30121_paid.json
@@ -6,6 +6,7 @@
   "approvedBy": "b72a28f6-04fc-489f-be18-ad53a3a64f67",
   "approvalDate": "2018-07-26T00:00:00Z",
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "30121",
   "invoiceDate": "2018-07-25T00:00:00Z",
   "paymentTerms": "Payment in Advance",

--- a/src/main/resources/data/invoices/45723_canceled.json
+++ b/src/main/resources/data/invoices/45723_canceled.json
@@ -4,6 +4,7 @@
   ],
   "adjustmentsTotal": 0.00,
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "45723",
   "invoiceDate": "2018-07-20T00:00:00Z",
   "paymentMethod": "EFT",

--- a/src/main/resources/data/invoices/82912_open.json
+++ b/src/main/resources/data/invoices/82912_open.json
@@ -4,6 +4,7 @@
   ],
   "adjustmentsTotal": -10.00,
   "currency": "USD",
+  "exportToAccounting": false,
   "folioInvoiceNo": "82912",
   "invoiceDate": "2018-07-27T00:00:00.000+0000",
   "paymentMethod": "EFT",


### PR DESCRIPTION
## Purpose
[MODINVOSTO-24](https://issues.folio.org/browse/MODINVOSTO-24) add billTo and exportToAccounting properties

## Approach
Pointing to acq-models with updates
Note: `billTo` is not added to the sample data because there is no static sample data for addresses in mod-configs

#### TODOS and Open Questions
- [x] Merge together with https://github.com/folio-org/mod-invoice/pull/38

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
