### PR TITLE
MODINVOSTO-29: Implement basic CRUD for /voucher-storage/acquisitions-unit-assignments

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -387,7 +387,8 @@
         "voucher-storage.voucher-lines.item.get",
         "voucher-storage.voucher-lines.item.post",
         "voucher-storage.voucher-lines.item.put",
-        "voucher-storage.voucher-lines.item.delete"
+        "voucher-storage.voucher-lines.item.delete",
+        "voucher-storage.acquisitions-unit-assignments.all"
       ],
       "visible": false
     },
@@ -483,8 +484,7 @@
         "invoice-storage.invoice-number.get",
         "invoice-storage.invoice-line-number.get",
         "voucher-storage.module.all",
-        "invoice-storage.acquisitions-unit-assignments.all",
-        "voucher-storage.acquisitions-unit-assignments.all"
+        "invoice-storage.acquisitions-unit-assignments.all"
       ],
       "visible": false
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -202,6 +202,37 @@
       ]
     },
     {
+      "id": "voucher-storage.acquisitions-unit-assignments",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/voucher-storage/acquisitions-unit-assignments",
+          "permissionsRequired": ["voucher-storage.acquisitions-unit-assignments.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/voucher-storage/acquisitions-unit-assignments",
+          "permissionsRequired": ["voucher-storage.acquisitions-unit-assignments.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/voucher-storage/acquisitions-unit-assignments/{id}",
+          "permissionsRequired": ["voucher-storage.acquisitions-unit-assignments.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/voucher-storage/acquisitions-unit-assignments/{id}",
+          "permissionsRequired": ["voucher-storage.acquisitions-unit-assignments.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/voucher-storage/acquisitions-unit-assignments/{id}",
+          "permissionsRequired": ["voucher-storage.acquisitions-unit-assignments.item.delete"]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "1.2",
       "interfaceType": "system",
@@ -398,6 +429,43 @@
       ]
     },
     {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.collection.get",
+      "displayName" : "acquisitions-unit-assignments-collection get",
+      "description" : "Get a collection of acquisitions unit assignments to use voucher"
+    },
+    {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.item.post",
+      "displayName" : "acquisitions-unit-assignment-item post",
+      "description" : "Create a new acquisitions unit assignment to use voucher"
+    },
+    {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.item.get",
+      "displayName" : "acquisitions-unit-assignment-item get",
+      "description" : "Fetch an acquisitions unit assignment to use voucher"
+    },
+    {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.item.put",
+      "displayName" : "acquisitions-unit-assignment put",
+      "description" : "Update an acquisitions unit assignment to use voucher"
+    },
+    {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.item.delete",
+      "displayName" : "acquisitions-unit-assignment-item delete",
+      "description" : "Delete an acquisitions unit assignment associated to use voucher"
+    },
+    {
+      "permissionName" : "voucher-storage.acquisitions-unit-assignments.all",
+      "displayName" : "All acquisitions-unit-assignment perms",
+      "description" : "All permissions for the acquisitions-unit-assignments associated to voucher",
+      "subPermissions" : [
+        "voucher-storage.acquisitions-unit-assignments.collection.get",
+        "voucher-storage.acquisitions-unit-assignments.item.post",
+        "voucher-storage.acquisitions-unit-assignments.item.get",
+        "voucher-storage.acquisitions-unit-assignments.item.put",
+        "voucher-storage.acquisitions-unit-assignments.item.delete"
+      ]
+    },
+    {
       "permissionName": "invoice-storage.module.all",
       "displayName": "Invoice storage module - all permissions",
       "description": "Entire set of permissions needed to use the invoice module",
@@ -415,7 +483,8 @@
         "invoice-storage.invoice-number.get",
         "invoice-storage.invoice-line-number.get",
         "voucher-storage.module.all",
-        "invoice-storage.acquisitions-unit-assignments.all"
+        "invoice-storage.acquisitions-unit-assignments.all",
+        "voucher-storage.acquisitions-unit-assignments.all"
       ],
       "visible": false
     }

--- a/ramls/acquisitions-unit-assignments.raml
+++ b/ramls/acquisitions-unit-assignments.raml
@@ -54,3 +54,32 @@ resourceTypes:
     put:
       description: Update acquisitions unit assignment
       is: [validate]
+
+/voucher-storage/acquisitions-unit-assignments:
+  type:
+    collection:
+      exampleCollection: !include acq-models/common/examples/acquisitions_unit_assignment_collection.sample
+      exampleItem: !include acq-models/common/examples/acquisitions_unit_assignment_post.sample
+      schemaCollection: acquisitions-unit-assignment-collection
+      schemaItem: acquisitions-unit-assignment
+  post:
+    description: Create new acquisitions unit assignment
+    is: [validate]
+  get:
+    description: Get list of acquisitions unit assignments
+    is: [
+      searchable: {description: "with valid searchable fields: for example recordId", example: "[\"recordId\", \"a9b99f8a-7100-47f2-9903-6293d44a9905\"]"},
+      pageable
+    ]
+  /{id}:
+    uriParameters:
+      id:
+        description: The UUID of a acquisitions unit assignment
+        type: UUID
+    type:
+      collection-item:
+        exampleItem: !include acq-models/common/examples/acquisitions_unit_assignment_get.sample
+        schema: acquisitions-unit-assignment
+    put:
+      description: Update acquisitions unit assignment
+      is: [validate]

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitAssignmentAPI.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitAssignmentAPI.java
@@ -10,6 +10,7 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.AcquisitionsUnitAssignment;
 import org.folio.rest.jaxrs.model.AcquisitionsUnitAssignmentCollection;
 import org.folio.rest.jaxrs.resource.InvoiceStorageAcquisitionsUnitAssignments;
+import org.folio.rest.jaxrs.resource.VoucherStorageAcquisitionsUnitAssignments;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.QueryHolder;
@@ -18,9 +19,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
-public class AcquisitionsUnitAssignmentAPI implements InvoiceStorageAcquisitionsUnitAssignments {
+public class AcquisitionsUnitAssignmentAPI implements InvoiceStorageAcquisitionsUnitAssignments, VoucherStorageAcquisitionsUnitAssignments {
   private static final String ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE = "acquisitions_unit_assignments";
+  private static final String VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE = "voucher_acquisitions_unit_assignments";
 
+  
   @Override
   @Validate
   public void postInvoiceStorageAcquisitionsUnitAssignments(String lang, AcquisitionsUnitAssignment entity,
@@ -59,5 +62,45 @@ public class AcquisitionsUnitAssignmentAPI implements InvoiceStorageAcquisitions
   public void deleteInvoiceStorageAcquisitionsUnitAssignmentsById(String id, String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.deleteById(ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, id, okapiHeaders, vertxContext, DeleteInvoiceStorageAcquisitionsUnitAssignmentsByIdResponse.class, asyncResultHandler);
+  }
+
+  @Validate
+  @Override
+  public void postVoucherStorageAcquisitionsUnitAssignments(String lang, AcquisitionsUnitAssignment entity,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.post(VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, entity, okapiHeaders, vertxContext, PostVoucherStorageAcquisitionsUnitAssignmentsResponse.class, asyncResultHandler);
+  }
+
+  @Validate
+  @Override
+  public void getVoucherStorageAcquisitionsUnitAssignments(String query, int offset, int limit, String lang,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext((Void v) -> {
+      EntitiesMetadataHolder<AcquisitionsUnitAssignment, AcquisitionsUnitAssignmentCollection> entitiesMetadataHolder = new EntitiesMetadataHolder<>(
+          AcquisitionsUnitAssignment.class, AcquisitionsUnitAssignmentCollection.class, GetVoucherStorageAcquisitionsUnitAssignmentsResponse.class);
+      QueryHolder cql = new QueryHolder(VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, query, offset, limit, lang);
+      getEntitiesCollection(entitiesMetadataHolder, cql, asyncResultHandler, vertxContext, okapiHeaders);
+    });
+  }
+
+  @Validate
+  @Override
+  public void putVoucherStorageAcquisitionsUnitAssignmentsById(String id, String lang, AcquisitionsUnitAssignment entity,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.put(VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, entity, id, okapiHeaders, vertxContext, PutVoucherStorageAcquisitionsUnitAssignmentsByIdResponse.class, asyncResultHandler);
+  }
+
+  @Validate
+  @Override
+  public void getVoucherStorageAcquisitionsUnitAssignmentsById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.getById(VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, AcquisitionsUnitAssignment.class, id, okapiHeaders, vertxContext, GetVoucherStorageAcquisitionsUnitAssignmentsByIdResponse.class, asyncResultHandler);
+  }
+
+  @Validate
+  @Override
+  public void deleteVoucherStorageAcquisitionsUnitAssignmentsById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.deleteById(VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE, id, okapiHeaders, vertxContext, DeleteVoucherStorageAcquisitionsUnitAssignmentsByIdResponse.class, asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -57,8 +57,6 @@ public class TenantReferenceAPI extends TenantAPI {
 
   }
 
-
-
   private boolean buildDataLoadingParameters(TenantAttributes tenantAttributes, TenantLoading tl) {
     boolean loadData = false;
     if (isLoadSample(tenantAttributes)) {
@@ -68,7 +66,8 @@ public class TenantReferenceAPI extends TenantAPI {
         .add("invoice-lines", "invoice-storage/invoice-lines")
         .add("vouchers", "voucher-storage/vouchers")
         .add("voucher-lines", "voucher-storage/voucher-lines")
-        .add("acquisitions-unit-assignments", "invoice-storage/acquisitions-unit-assignments");
+        .add("acquisitions-unit-assignments", "invoice-storage/acquisitions-unit-assignments")
+        .add("voucher-acquisitions-unit-assignments", "voucher-storage/acquisitions-unit-assignments");
       loadData = true;
     }
     return loadData;

--- a/src/main/resources/data/voucher-acquisitions-unit-assignments/AUA-5c499700.json
+++ b/src/main/resources/data/voucher-acquisitions-unit-assignments/AUA-5c499700.json
@@ -1,0 +1,5 @@
+{
+  "id": "0b44b189-0268-4dd0-825d-faa462bdf137",
+  "recordId": "a9b99f8a-7100-47f2-9903-6293d44a9905",
+  "acquisitionsUnitId": "0ebb1f7d-983f-3026-8a4c-5318e0ebc041"
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -66,6 +66,27 @@
           "tOps": "ADD"
         }
       ]
+    },
+    {
+      "tableName": "voucher_acquisitions_unit_assignments",
+      "fromModuleVersion": 1.0,
+      "withMetadata": true,
+      "foreignKeys": [
+        {
+          "fieldName": "recordId",
+          "targetTable": "vouchers"
+        }
+      ],
+      "index": [
+        {
+          "fieldName": "recordId",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "acquisitionsUnitId",
+          "tOps": "ADD"
+        }
+      ]
     }
   ]
 }

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -24,6 +24,7 @@ class EntitiesCrudTest extends TestBase {
 
   static Stream<TestEntities> deleteOrder() {
     return Stream.of(
+      TestEntities.VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS,
       TestEntities.ACQUISITIONS_UNIT_ASSIGNMENTS,
       TestEntities.VOUCHER_LINES,
       TestEntities.VOUCHER,
@@ -39,6 +40,7 @@ class EntitiesCrudTest extends TestBase {
 
   static Stream<TestEntities> createFailOrder() {
     return Stream.of(
+      TestEntities.VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS,
       TestEntities.ACQUISITIONS_UNIT_ASSIGNMENTS,
       TestEntities.VOUCHER_LINES,
       TestEntities.VOUCHER,
@@ -51,7 +53,6 @@ class EntitiesCrudTest extends TestBase {
   void testVerifyCollection(TestEntities testEntity) throws MalformedURLException {
     logger.info(String.format("--- mod-invoice-storage %s test: Verifying database's initial state ... ", testEntity.name()));
     verifyCollectionQuantity(testEntity.getEndpoint(), 0);
-
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/utils/TenantApiTestUtil.java
+++ b/src/test/java/org/folio/rest/utils/TenantApiTestUtil.java
@@ -5,7 +5,6 @@ import io.restassured.http.Header;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
 import java.net.MalformedURLException;
 
 import static io.restassured.RestAssured.given;
@@ -13,7 +12,7 @@ import static org.folio.rest.impl.StorageTestSuite.URL_TO_HEADER;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
 
 public class TenantApiTestUtil {
-
+  
   public static final String TENANT_ENDPOINT = "/_/tenant";
   private static final Header USER_ID_HEADER = new Header("X-Okapi-User-id", "28d0fb04-d137-11e8-a8d5-f2801f1b9fd1");
 
@@ -21,17 +20,18 @@ public class TenantApiTestUtil {
 
   }
 
-	public static JsonObject prepareTenantBody(boolean isLoadSampleData, boolean isUpgrade) {
-		JsonArray parameterArray = new JsonArray();
-		parameterArray.add(new JsonObject().put("key", "loadSample").put("value", isLoadSampleData));
-		JsonObject jsonBody = new JsonObject();
-		jsonBody.put("module_to", "mod-invoice-storage-1.0.0");
-		jsonBody.put("parameters", parameterArray);
-		if (isUpgrade) {
-			jsonBody.put("module_from", "mod-invoice-storage-1.0.0");
-		}
-		return jsonBody;
-	}
+  public static JsonObject prepareTenantBody(boolean isLoadSampleData, boolean isUpgrade) {
+    JsonArray parameterArray = new JsonArray();
+    parameterArray.add(new JsonObject().put("key", "loadSample")
+      .put("value", isLoadSampleData));
+    JsonObject jsonBody = new JsonObject();
+    jsonBody.put("module_to", "mod-invoice-storage-1.0.0");
+    jsonBody.put("parameters", parameterArray);
+    if (isUpgrade) {
+      jsonBody.put("module_from", "mod-invoice-storage-1.0.0");
+    }
+    return jsonBody;
+  }
 
   public static void prepareTenant(Header tenantHeader, boolean isLoadSampleData) throws MalformedURLException {
     JsonObject jsonBody = prepareTenantBody(isLoadSampleData, false);

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -12,7 +12,8 @@ public enum TestEntities {
   INVOICE_LINES("/invoice-storage/invoice-lines", InvoiceLine.class, "invoice-lines/123invoicenumber45-1.json", "quantity", 5, 9),
   VOUCHER("/voucher-storage/vouchers", Voucher.class, "vouchers/test_voucher.json", "batchNumber", "202", 1),
   VOUCHER_LINES("/voucher-storage/voucher-lines", VoucherLine.class, "voucher-lines/test_voucher_line.json", "externalAccountNumber", "Comment from unit test", 1),
-  ACQUISITIONS_UNIT_ASSIGNMENTS("/invoice-storage/acquisitions-unit-assignments", AcquisitionsUnitAssignment.class, "acquisitions-unit-assignments/AUA-5c499782.json", "recordId", "733cafd3-895f-4e33-87b7-bf40dc3c8069", 1);
+  ACQUISITIONS_UNIT_ASSIGNMENTS("/invoice-storage/acquisitions-unit-assignments", AcquisitionsUnitAssignment.class, "acquisitions-unit-assignments/AUA-5c499782.json", "recordId", "733cafd3-895f-4e33-87b7-bf40dc3c8069", 1),
+  VOUCHER_ACQUISITIONS_UNIT_ASSIGNMENTS("/voucher-storage/acquisitions-unit-assignments", AcquisitionsUnitAssignment.class, "voucher-acquisitions-unit-assignments/AUA-5c499700.json", "recordId", "a9b99f8a-7100-47f2-9903-6293d44a9905", 1);
 
   private static final String SAMPLES_PATH = "data/";
   TestEntities(String endpoint, Class<?> clazz, String sampleFileName, String updatedFieldName, Object updatedFieldValue, int initialQuantity) {
@@ -23,7 +24,6 @@ public enum TestEntities {
     this.updatedFieldValue = updatedFieldValue;
     this.initialQuantity = initialQuantity;
   }
-
 
   private int initialQuantity;
   private String endpoint;


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODINVOSTO-29

## Approach
* ModuleDescriptor, RAML are updated
* Implemented CRUD for /voucher-storage/acquisitions-unit-assignments
* Index added on recordId field
* Add unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
