### PR TITLE
MODINVOICE-86/87 - invoice and invoice line totals are not readonly

### DIFF
--- a/src/main/resources/data/invoice-lines/123invoicenumber45-1.json
+++ b/src/main/resources/data/invoice-lines/123invoicenumber45-1.json
@@ -16,6 +16,7 @@
       "relationToTotal":"In addition to"
     }
   ],
+  "adjustmentsTotal": 55.00,
   "description": "Some description",
   "fundDistributions": [
     {
@@ -43,6 +44,7 @@
   "subscriptionStart": "2018-08-01T00:00:00.000+0000",
   "subscriptionEnd": "2019-01-01T00:00:00.000+0000",
   "subTotal": 1000.00,
+  "total": 1055.00,
   "vendorRefNo": "1"
 }
 

--- a/src/main/resources/data/invoices/123invoicenumber45_approved_for_2_orders.json
+++ b/src/main/resources/data/invoices/123invoicenumber45_approved_for_2_orders.json
@@ -3,6 +3,7 @@
   "accountingCode": "1234",
   "adjustments": [
   ],
+  "adjustmentsTotal": 45.00,
   "currency": "USD",
   "exportToAccounting": false,
   "folioInvoiceNo": "123invoicenumber45",
@@ -12,6 +13,8 @@
   "paymentMethod": "EFT",
   "status": "Approved",
   "source": "User",
+  "subTotal": 1150.00,
+  "total": 1195.00,
   "vendorInvoiceNo": "YK75851",
   "voucherNumber": "478",
   "poNumbers": [

--- a/src/main/resources/data/invoices/30121_paid.json
+++ b/src/main/resources/data/invoices/30121_paid.json
@@ -3,7 +3,7 @@
   "accountingCode": "5678",
   "adjustments": [
   ],
-  "adjustmentsTotal": 0.00,
+  "adjustmentsTotal": -200.00,
   "approvedBy": "b72a28f6-04fc-489f-be18-ad53a3a64f67",
   "approvalDate": "2018-07-26T00:00:00Z",
   "currency": "USD",
@@ -15,7 +15,7 @@
   "status": "Paid",
   "source": "User",
   "subTotal": 200000.00,
-  "total": 200000.00,
+  "total": 199800.00,
   "vendorInvoiceNo": "NM23141",
   "voucherNumber": "223",
   "poNumbers": [

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -23,6 +23,7 @@ import org.junit.BeforeClass;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -50,8 +51,8 @@ public abstract class TestBase {
     }
   }
 
-  void verifyCollectionQuantity(String endpoint, int quantity, Header tenantHeader) throws MalformedURLException {
-    getData(endpoint, tenantHeader)
+  ValidatableResponse verifyCollectionQuantity(String endpoint, int quantity, Header tenantHeader) throws MalformedURLException {
+    return getData(endpoint, tenantHeader)
       .then()
       .log().all()
       .statusCode(200)
@@ -90,7 +91,7 @@ public abstract class TestBase {
         .extract()
           .path("id");
   }
-  
+
   @AfterClass
   public static void testBaseAfterClass()
     throws InterruptedException,
@@ -109,7 +110,7 @@ public abstract class TestBase {
         .statusCode(200)
         .body("id", equalTo(id));
   }
-  
+
   Response getDataById(String endpoint, String id) throws MalformedURLException {
     return given()
       .pathParam("id", id)
@@ -117,17 +118,17 @@ public abstract class TestBase {
       .contentType(ContentType.JSON)
       .get(storageUrl(endpoint));
   }
-  
+
   Response getData(String endpoint) throws MalformedURLException {
     return getData(endpoint, TENANT_HEADER);
   }
-  
+
   void testEntityEdit(String endpoint, String entitySample, String id) throws MalformedURLException {
     putData(endpoint, id, entitySample)
       .then().log().ifValidationFails()
       .statusCode(204);
   }
-  
+
   void testFetchingUpdatedEntity(String id, TestEntities subObject) throws MalformedURLException {
     Object existedValue = getDataById(subObject.getEndpointWithId(), id)
       .then()
@@ -138,7 +139,7 @@ public abstract class TestBase {
               .get(subObject.getUpdatedFieldName());
     assertEquals(existedValue, subObject.getUpdatedFieldValue());
   }
-  
+
   Response putData(String endpoint, String id, String input) throws MalformedURLException {
     return given()
       .pathParam("id", id)
@@ -147,7 +148,7 @@ public abstract class TestBase {
         .body(input)
           .put(storageUrl(endpoint));
   }
-  
+
   Response putInvoiceNumberData(String id, String input) throws MalformedURLException {
     return given()
       .pathParam("id", id)
@@ -156,7 +157,7 @@ public abstract class TestBase {
       .body(input)
         .put(storageUrl(INVOICE.getEndpointWithId()));
   }
-  
+
   void deleteDataSuccess(String endpoint, String id) throws MalformedURLException {
     deleteData(endpoint, id)
       .then().log().ifValidationFails()
@@ -174,18 +175,18 @@ public abstract class TestBase {
       .contentType(ContentType.JSON)
       .delete(storageUrl(endpoint));
   }
-  
+
   void testVerifyEntityDeletion(String endpoint, String id) throws MalformedURLException {
     getDataById(endpoint, id)
       .then()
         .statusCode(404);
   }
-  
+
   void testInvalidCQLQuery(String endpoint) throws MalformedURLException {
     getData(endpoint).then().log().ifValidationFails()
       .statusCode(400);
   }
-  
+
   Response getDataByParam(String endpoint, Map<String, Object> params) throws MalformedURLException {
     return given()
       .params(params)
@@ -193,7 +194,7 @@ public abstract class TestBase {
       .contentType(ContentType.JSON)
         .get(storageUrl(endpoint));
   }
-  
+
   void testAllFieldsExists(JsonObject extracted, JsonObject sampleObject) {
     sampleObject.remove("id");
     Set<String> fieldsNames = sampleObject.fieldNames();
@@ -207,7 +208,7 @@ public abstract class TestBase {
     }
   }
 
-  
+
   static String getFile(String filename) {
     String value = "";
     try (InputStream inputStream = TestBase.class.getClassLoader().getResourceAsStream(filename)) {


### PR DESCRIPTION
## Purpose
[MODINVOICE-86](https://issues.folio.org/browse/MODINVOICE-86) Calculate and persist totals upon invoiceLine creation/update
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87) Calculate and persist totals upon invoice creation/update/get
## Approach
- Pointing to updated acq-models where `readonly` has been removed for following properties because they have to be persisted:
  - `invoice.json`: `adjustmentsTotal` and `subTotal`
  - `invoice_line.json`: `adjustmentsTotal` and `total`
- Updating sample data

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
