### PR TITLE
MODINVOSTO-39 - Release 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,20 @@
-## 1.1.0 - Unreleased
+## 2.1.0 - Unreleased
+
+## 2.0.0 - Released
+
+The primary focus of this release was to allow cross table index queries and provide the APIs for managing invoice attachments.
+
+[Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v1.0.0...v2.0.0)
+
+### Stories
+* [MODINVOICE-77](https://issues.folio.org/browse/MODINVOICE-77) - Invoice and invoiceLine schema updates (breaking changes)
+* [MODINVOSTO-35](https://issues.folio.org/browse/MODINVOSTO-35) - Cleanup acquisition-units-assignments APIs/views/etc. (breaking changes)
+* [MODINVOSTO-34](https://issues.folio.org/browse/MODINVOSTO-34) - Implement API for invoice attachments (links/documents)
+* [MODINVOSTO-31](https://issues.folio.org/browse/MODINVOSTO-31) - Voucher/voucher line cross table index queries
+* [MODINVOSTO-28](https://issues.folio.org/browse/MODINVOSTO-28) - Invoice/invoice line cross table index queries
+
+### Bug Fixes
+* [MODINVOSTO-38](https://issues.folio.org/browse/MODINVOSTO-38) - MOD-INVOICE-STORAGE fails after several runs of API tests
 
 ## 1.0.0 - Released
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "invoice-storage.invoices",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -55,7 +55,7 @@
     },
     {
       "id": "invoice-storage.invoice-lines",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -109,7 +109,7 @@
     {
 
       "id": "voucher-storage.vouchers",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -140,7 +140,7 @@
     },
     {
       "id": "voucher-storage.voucher-lines",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,20 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>org.folio:raml-module-builder</artifact>
+                  <excludes>
+                    <exclude>**/log4j2.properties</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/log4j.properties</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.folio</groupId>
     <artifactId>mod-invoice-storage</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -443,7 +443,7 @@
         <url>https://github.com/folio-org/mod-invoice-storage</url>
         <connection>scm:git:git://github.com/folio-org/mod-invoice-storage.git</connection>
         <developerConnection>scm:git:git@github.com:folio-org/mod-invoice-storage.git</developerConnection>
-        <tag>v2.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.folio</groupId>
     <artifactId>mod-invoice-storage</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -20,7 +20,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.46</jmockit.version>
-    <argLine/>
+    <argLine />
   </properties>
 
   <dependencyManagement>
@@ -443,7 +443,7 @@
         <url>https://github.com/folio-org/mod-invoice-storage</url>
         <connection>scm:git:git://github.com/folio-org/mod-invoice-storage.git</connection>
         <developerConnection>scm:git:git@github.com:folio-org/mod-invoice-storage.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v2.0.0</tag>
     </scm>
 
 </project>

--- a/ramls/invoice.raml
+++ b/ramls/invoice.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Invoices
-version: v1
+version: v2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://github.com/folio-org/mod-invoice-storage
 

--- a/ramls/voucher.raml
+++ b/ramls/voucher.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Vouchers
-version: v1
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://github.com/folio-org/mod-invoice-storage
 
@@ -77,4 +77,4 @@ resourceTypes:
           schema: voucherLine
           exampleItem: !include acq-models/mod-invoice-storage/examples/voucher_line.sample
       put:
-        is: [validate]      
+        is: [validate]

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,15 @@
+status = info
+dest = err
+name = PropertiesConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%-25t] %c{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.netty.name = io.netty
+logger.netty.level = info
+logger.netty.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -48,7 +48,7 @@
     },
     {
       "tableName": "documents",
-      "fromModuleVersion": 1.1,
+      "fromModuleVersion": 2.0,
       "withMetadata": true,
       "foreignKeys": [
         {


### PR DESCRIPTION
## Purpose
[MODINVOSTO-39](https://issues.folio.org/browse/MODINVOSTO-39) Release 2.0.0

## Approach
- Updating News.md
- Updating interface version

Interface | Version | Reason for change
------------ | ------------- | -------------
`invoice-storage.invoices` | 2.0 | [MODINVOICE-77](https://issues.folio.org/browse/MODINVOICE-77) as breaking change
`invoice-storage.invoice-lines` | 1.1 | [MODINVOICE-77](https://issues.folio.org/browse/MODINVOICE-77) + cross table queries
`voucher-storage.vouchers` | 1.1 | [MODINVOSTO-31](https://issues.folio.org/browse/MODINVOSTO-31)
`voucher-storage.voucher-lines` | 1.1 | [MODINVOSTO-31](https://issues.folio.org/browse/MODINVOSTO-31)


#### TODOS and Open Questions
- [ ] Merge only with release PR for mod-invoice

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [x] Did any of the interface versions change?