### PR TITLE
MODINVOSTO-40 Remove unique index on voucherNumber

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -25,7 +25,7 @@
       "uniqueIndex": [
         {
           "fieldName": "voucherNumber",
-          "tOps": "ADD"
+          "tOps": "DELETE"
         }
       ],
       "foreignKeys": [

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -18,8 +18,8 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
 import org.folio.rest.utils.TestEntities;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
@@ -46,7 +46,7 @@ public abstract class TestBase {
 
   public static final String ID = "id";
 
-  @BeforeClass
+  @BeforeAll
   public static void testBaseBeforeClass() throws InterruptedException, ExecutionException, TimeoutException, IOException {
     Vertx vertx = StorageTestSuite.getVertx();
     if (vertx == null) {
@@ -90,6 +90,10 @@ public abstract class TestBase {
       .post(storageUrl(endpoint));
   }
 
+  String createEntity(String endpoint, Object input) throws MalformedURLException {
+    return createEntity(endpoint, JsonObject.mapFrom(input).encode());
+  }
+
   String createEntity(String endpoint, String entity) throws MalformedURLException {
     return postData(endpoint, entity)
       .then().log().ifValidationFails()
@@ -98,7 +102,7 @@ public abstract class TestBase {
           .path("id");
   }
 
-  @AfterClass
+  @AfterAll
   public static void testBaseAfterClass()
     throws InterruptedException,
     ExecutionException,

--- a/src/test/java/org/folio/rest/impl/VoucherNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/VoucherNumberTest.java
@@ -104,6 +104,9 @@ public class VoucherNumberTest extends TestBase {
     String voucherId1 = createEntity(TestEntities.VOUCHER.getEndpoint(), voucher.withId(randomUUID().toString()).withInvoiceId(invoiceId1));
     String voucherId2 = createEntity(TestEntities.VOUCHER.getEndpoint(), voucher.withId(randomUUID().toString()).withInvoiceId(invoiceId2));
 
+    // Make sure 2 vouchers are created with the same number
+    verifyCollectionQuantity(TestEntities.VOUCHER.getEndpoint() + "?query=voucherNumber==MODINVOSTO40", 2);
+
     deleteDataSuccess(TestEntities.VOUCHER.getEndpointWithId(), voucherId1);
     deleteDataSuccess(TestEntities.VOUCHER.getEndpointWithId(), voucherId2);
     deleteDataSuccess(TestEntities.INVOICE.getEndpointWithId(), invoiceId1);

--- a/src/test/java/org/folio/rest/impl/VoucherNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/VoucherNumberTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import static io.restassured.RestAssured.given;
+import static java.util.UUID.randomUUID;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -13,12 +14,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.folio.HttpStatus;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.Voucher;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.utils.TestEntities;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.UpdateResult;
 
 public class VoucherNumberTest extends TestBase {
@@ -57,9 +62,9 @@ public class VoucherNumberTest extends TestBase {
     changeStartValueResponse(start)
       .statusCode(HttpStatus.HTTP_NO_CONTENT.toInt());
 
-    // verify current start value equals new reseted start value 
+    // verify current start value equals new reseted start value
     assertThat(getCurrentStartValueVoucherNumber(), equalTo(start));
-    
+
     assertThat(getSequenceNumberValue(), is(start));
 
     // Negative scenario - changing start value with bad request
@@ -78,13 +83,33 @@ public class VoucherNumberTest extends TestBase {
       .statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
       .contentType(ContentType.TEXT);
   }
-  
+
   @Test
   public void testCurrentStartValueVoucherNumberInvalidUrl() throws MalformedURLException {
     getData(VOUCHER_NUMBER_INVALID_START_ENDPOINT).then()
       .statusCode(400);
   }
-  
+
+  @Test
+  public void testVoucherNumberIsNotUnique() throws MalformedURLException {
+    Invoice invoice = new JsonObject(getFile(TestEntities.INVOICE.getSampleFileName())).mapTo(Invoice.class);
+
+    String invoiceId1 = createEntity(TestEntities.INVOICE.getEndpoint(), invoice.withId(randomUUID().toString()));
+    String invoiceId2 = createEntity(TestEntities.INVOICE.getEndpoint(), invoice.withId(randomUUID().toString()));
+
+    Voucher voucher = new JsonObject(getFile(TestEntities.VOUCHER.getSampleFileName())).mapTo(Voucher.class)
+      .withVoucherNumber("MODINVOSTO40");
+
+    // Create vouchers for different invoices but with the same voucher number
+    String voucherId1 = createEntity(TestEntities.VOUCHER.getEndpoint(), voucher.withId(randomUUID().toString()).withInvoiceId(invoiceId1));
+    String voucherId2 = createEntity(TestEntities.VOUCHER.getEndpoint(), voucher.withId(randomUUID().toString()).withInvoiceId(invoiceId2));
+
+    deleteDataSuccess(TestEntities.VOUCHER.getEndpointWithId(), voucherId1);
+    deleteDataSuccess(TestEntities.VOUCHER.getEndpointWithId(), voucherId2);
+    deleteDataSuccess(TestEntities.INVOICE.getEndpointWithId(), invoiceId1);
+    deleteDataSuccess(TestEntities.INVOICE.getEndpointWithId(), invoiceId2);
+  }
+
   private long getCurrentStartValueVoucherNumber() throws MalformedURLException {
     return new Long(getData(VOUCHER_STORAGE_VOUCHER_NUMBER_START_ENDPOINT)
       .then()
@@ -93,7 +118,7 @@ public class VoucherNumberTest extends TestBase {
           .response()
             .path(SEQUENCE_NUMBER));
   }
-  
+
   private ValidatableResponse getSequenceNumberResponse() throws MalformedURLException {
     return given()
       .header(TENANT_HEADER)


### PR DESCRIPTION
## Purpose
[MODINVOSTO-40](https://issues.folio.org/browse/MODINVOSTO-40) Remove unique index on voucherNumber

## Approach
- Removing unique index
- Adding unit test to check that voucher with the same number can be created

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.