### PR TITLE
MODINVOSTO-61 - bootstrap batch_groups table

### DIFF
--- a/src/main/resources/templates/db_scripts/batch_groups.sql
+++ b/src/main/resources/templates/db_scripts/batch_groups.sql
@@ -1,0 +1,1 @@
+INSERT INTO ${myuniversity}_${mymodule}.batch_groups (id, jsonb) VALUES ('2a2cb998-1437-41d1-88ad-01930aaeadd5', '{"id": "2a2cb998-1437-41d1-88ad-01930aaeadd5", "name": "FOLIO"}') ON CONFLICT DO NOTHING;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -15,7 +15,8 @@
     {
       "tableName": "batch_groups",
       "fromModuleVersion": "mod-invoice-storage-3.1.0",
-      "withMetadata": true
+      "withMetadata": true,
+      "customSnippetPath": "batch_groups.sql"
     },
     {
       "tableName": "batch_voucher_export_configs",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -14,7 +14,7 @@
   "tables": [
     {
       "tableName": "batch_groups",
-      "fromModuleVersion": "mod-invoice-storage-3.1.0",
+      "fromModuleVersion": "mod-invoice-storage-3.1.1",
       "withMetadata": true,
       "customSnippetPath": "batch_groups.sql"
     },


### PR DESCRIPTION
## Purpose
We need to bootstrap the batch_groups table with the system data record "FOLIO" as part of the database migration scripts in order to satisfy FK constraints. See [MODINVOSTO-61](https://issues.folio.org/browse/MODINVOSTO-61) for details.

## Approach
Add a customSnippet to schema.json for the batch_groups table that inserts the record if it doesn't already exist.

NOTE;  This will be updated to include a description and metadata once the tenantLoading code runs.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
