### PR TITLE
[MODINVOSTO-57] Implementing cascade deletion for batch-voucher and b…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -244,7 +244,7 @@
     },
     {
       "id": "batch-voucher-storage.batch-vouchers",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["POST"],
@@ -265,7 +265,7 @@
     },
     {
       "id": "batch-voucher-storage.batch-voucher-exports",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["POST"],

--- a/src/main/java/org/folio/rest/impl/BatchVoucherExportsImpl.java
+++ b/src/main/java/org/folio/rest/impl/BatchVoucherExportsImpl.java
@@ -3,19 +3,27 @@ package org.folio.rest.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import javax.ws.rs.core.Response;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.BatchVoucherExport;
 import org.folio.rest.jaxrs.model.BatchVoucherExportCollection;
 import org.folio.rest.jaxrs.resource.BatchVoucherStorageBatchVoucherExports;
 import org.folio.rest.persist.PgUtil;
-
-import javax.ws.rs.core.Response;
-import java.util.Map;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.service.BatchVoucherExportsService;
 
 
 public class BatchVoucherExportsImpl implements BatchVoucherStorageBatchVoucherExports {
 
   public static final String BATCH_VOUCHER_EXPORTS_TABLE = "batch_voucher_exports";
+
+  private BatchVoucherExportsService batchVoucherExportsService;
+
+  public BatchVoucherExportsImpl(Vertx vertx, String tenantId) {
+    this.batchVoucherExportsService = new BatchVoucherExportsService(PostgresClient.getInstance(vertx, tenantId));
+  }
 
   @Validate
   @Override
@@ -46,8 +54,7 @@ public class BatchVoucherExportsImpl implements BatchVoucherStorageBatchVoucherE
   @Override
   public void deleteBatchVoucherStorageBatchVoucherExportsById(String id, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(BATCH_VOUCHER_EXPORTS_TABLE, id, okapiHeaders, vertxContext,
-      BatchVoucherStorageBatchVoucherExports.DeleteBatchVoucherStorageBatchVoucherExportsByIdResponse.class, asyncResultHandler);
+    batchVoucherExportsService.deleteBatchVoucherExportsById(id, vertxContext, asyncResultHandler);
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/impl/BatchVouchersImpl.java
+++ b/src/main/java/org/folio/rest/impl/BatchVouchersImpl.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import io.vertx.core.Vertx;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -13,9 +14,17 @@ import org.folio.rest.persist.PgUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.service.BatchVoucherService;
 
 public class BatchVouchersImpl implements BatchVoucherStorageBatchVouchers {
   private static final String BATCH_VOUCHERS_TABLE = "batch_vouchers";
+
+  private BatchVoucherService batchVoucherService;
+
+  public BatchVouchersImpl(Vertx vertx, String tenantId) {
+    this.batchVoucherService = new BatchVoucherService(PostgresClient.getInstance(vertx, tenantId));
+  }
 
   @Validate
   @Override
@@ -37,7 +46,6 @@ public class BatchVouchersImpl implements BatchVoucherStorageBatchVouchers {
   @Override
   public void deleteBatchVoucherStorageBatchVouchersById(String id, String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(BATCH_VOUCHERS_TABLE, id, okapiHeaders, vertxContext,
-        BatchVoucherStorageBatchVouchers.DeleteBatchVoucherStorageBatchVouchersByIdResponse.class, asyncResultHandler);
+    batchVoucherService.deleteBatchVoucherById(id, vertxContext, asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/persist/CriterionBuilder.java
+++ b/src/main/java/org/folio/rest/persist/CriterionBuilder.java
@@ -1,0 +1,25 @@
+package org.folio.rest.persist;
+
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+
+public class CriterionBuilder {
+
+  private Criteria criteria;
+
+  public CriterionBuilder() {
+    criteria = new Criteria();
+  }
+
+  public CriterionBuilder with(String filedName, String fieldValue) {
+    criteria
+      .addField("'" + filedName + "'")
+      .setOperation("=")
+      .setVal(fieldValue);
+    return this;
+  }
+
+  public Criterion build() {
+    return new Criterion(criteria);
+  }
+}

--- a/src/main/java/org/folio/rest/persist/Tx.java
+++ b/src/main/java/org/folio/rest/persist/Tx.java
@@ -1,0 +1,53 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.ext.sql.SQLConnection;
+
+public class Tx<T> {
+
+  private T entity;
+  private PostgresClient pgClient;
+  private AsyncResult<SQLConnection> sqlConnection;
+
+  public Tx(T entity, PostgresClient pgClient) {
+    this.entity = entity;
+    this.pgClient = pgClient;
+  }
+
+  public T getEntity() {
+    return entity;
+  }
+
+  public AsyncResult<SQLConnection> getConnection() {
+    return sqlConnection;
+  }
+
+  public Future<Tx<T>> startTx() {
+    Promise<Tx<T>> promise = Promise.promise();
+
+    pgClient.startTx(connectionAsyncResult -> {
+      this.sqlConnection = connectionAsyncResult;
+      promise.complete(this);
+    });
+
+    return promise.future();
+  }
+
+  public Future<Tx<T>> endTx() {
+    Promise<Tx<T>> promise = Promise.promise();
+    pgClient.endTx(sqlConnection, v -> promise.complete(this));
+    return promise.future();
+  }
+
+  public Future<Void> rollbackTransaction() {
+    Promise<Void> promise = Promise.promise();
+    if (sqlConnection.failed()) {
+      promise.fail(sqlConnection.cause());
+    } else {
+      pgClient.rollbackTx(sqlConnection, promise);
+    }
+    return promise.future();
+  }
+}

--- a/src/main/java/org/folio/rest/util/ResponseUtils.java
+++ b/src/main/java/org/folio/rest/util/ResponseUtils.java
@@ -1,0 +1,77 @@
+package org.folio.rest.util;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+import javax.ws.rs.core.Response;
+import org.folio.rest.persist.PgExceptionUtil;
+import org.folio.rest.persist.Tx;
+
+public class ResponseUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ResponseUtils.class);
+
+  private ResponseUtils() {
+  }
+
+  public static <T> Handler<AsyncResult<Tx<T>>> handleNoContentResponse(Handler<AsyncResult<Response>> asyncResultHandler, Tx<T> tx,
+    String logMessage) {
+    return result -> {
+      if (result.failed()) {
+        HttpStatusException cause = (HttpStatusException) result.cause();
+        logger.error(logMessage, cause, tx.getEntity(), "or associated data failed to be");
+
+        // The result of rollback operation is not so important, main failure cause is used to build the response
+        tx.rollbackTransaction().setHandler(res -> asyncResultHandler.handle(buildErrorResponse(cause)));
+      } else {
+        logger.info(logMessage, tx.getEntity(), "and associated data were successfully");
+        asyncResultHandler.handle(buildNoContentResponse());
+      }
+    };
+  }
+
+  public static void handleFailure(Promise promise, AsyncResult reply) {
+    Throwable cause = reply.cause();
+    String badRequestMessage = PgExceptionUtil.badRequestMessage(cause);
+    if (badRequestMessage != null) {
+      promise.fail(new HttpStatusException(Response.Status.BAD_REQUEST.getStatusCode(), badRequestMessage));
+    } else {
+      promise.fail(new HttpStatusException(INTERNAL_SERVER_ERROR.getStatusCode(), cause.getMessage()));
+    }
+  }
+
+  public static Future<Response> buildNoContentResponse() {
+    return Future.succeededFuture(Response.noContent().build());
+  }
+
+  public static Future<Response> buildErrorResponse(Throwable throwable) {
+    final String message;
+    final int code;
+
+    if (throwable instanceof HttpStatusException) {
+      code = ((HttpStatusException) throwable).getStatusCode();
+      message = ((HttpStatusException) throwable).getPayload();
+    } else {
+      code = INTERNAL_SERVER_ERROR.getStatusCode();
+      message = throwable.getMessage();
+    }
+
+    return Future.succeededFuture(buildErrorResponse(code, message));
+  }
+
+  private static Response buildErrorResponse(int code, String message) {
+    return Response.status(code)
+      .header(CONTENT_TYPE, TEXT_PLAIN)
+      .entity(message)
+      .build();
+  }
+
+}

--- a/src/main/java/org/folio/service/BatchVoucherExportsService.java
+++ b/src/main/java/org/folio/service/BatchVoucherExportsService.java
@@ -1,0 +1,96 @@
+package org.folio.service;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.folio.rest.impl.BatchVoucherExportsImpl.BATCH_VOUCHER_EXPORTS_TABLE;
+import static org.folio.rest.util.ResponseUtils.handleNoContentResponse;
+
+import com.google.common.collect.Maps;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.rest.jaxrs.model.BatchVoucherExport;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.CriterionBuilder;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Tx;
+
+public class BatchVoucherExportsService {
+
+  private static final String BATCH_VOUCHER_EXPORT_ID = "batchVoucherExportId";
+  private static final String BATCH_VOUCHER_ID = "batchVoucherId";
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private PostgresClient pgClient;
+
+  public BatchVoucherExportsService(PostgresClient pgClient) {
+    this.pgClient = pgClient;
+  }
+
+  public void deleteBatchVoucherExportsById(String id, Context vertxContext, Handler<AsyncResult<Response>> asyncResultHandler) {
+
+    BatchVoucherService batchVoucherService = new BatchVoucherService(pgClient);
+
+    vertxContext.runOnContext((v) -> {
+      Tx<Map<String, String>> tx = new Tx<>(Maps.newHashMap(of(BATCH_VOUCHER_EXPORT_ID, id)), pgClient);
+
+      tx.startTx()
+        .compose(this::getAssociatedBatchVoucherId)
+        .compose(this::deleteBatchVoucherExportById)
+        .compose(batchVoucherService::deleteBatchVoucherById)
+        .compose(Tx::endTx)
+        .setHandler(handleNoContentResponse(asyncResultHandler, tx, "Batch voucher exports {} {} deleted"));
+    });
+  }
+
+  public Future<Tx<Map<String, String>>> deleteBatchVoucherExportById(Tx<Map<String, String>> tx) {
+    Promise<Tx<Map<String, String>>> promise = Promise.promise();
+
+    pgClient.delete(tx.getConnection(), BATCH_VOUCHER_EXPORTS_TABLE, tx.getEntity().get(BATCH_VOUCHER_EXPORT_ID), (rs) -> {
+      logger.info("deletion of batch voucher exports completed ");
+      if (rs.result().getUpdated() == 0) {
+        promise.fail(new HttpStatusException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
+      } else {
+        promise.complete(tx);
+      }
+    });
+    return promise.future();
+  }
+
+  public Future<Tx<Map<String, String>>> deleteBatchVoucherExportsByBatchVoucherId(Tx<Map<String, String>> tx) {
+    Promise<Tx<Map<String, String>>> promise = Promise.promise();
+
+    Criterion criterion = new CriterionBuilder()
+      .with(BATCH_VOUCHER_ID, tx.getEntity().get(BATCH_VOUCHER_ID)).build();
+
+    pgClient.delete(tx.getConnection(), BATCH_VOUCHER_EXPORTS_TABLE, criterion, (rs) -> {
+      logger.info("deletion of batch voucher exports completed ");
+      if (rs.failed()) {
+        promise.fail(new HttpStatusException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
+      } else {
+        promise.complete(tx);
+      }
+    });
+    return promise.future();
+  }
+
+  public Future<Tx<Map<String, String>>> getAssociatedBatchVoucherId(Tx<Map<String, String>> tx) {
+    Promise<Tx<Map<String, String>>> promise = Promise.promise();
+
+    pgClient.getById(BATCH_VOUCHER_EXPORTS_TABLE, tx.getEntity().get(BATCH_VOUCHER_EXPORT_ID), BatchVoucherExport.class, (rs) -> {
+      if (rs.failed() || rs.result() == null) {
+        promise.fail(new HttpStatusException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
+      } else {
+        tx.getEntity().put(BATCH_VOUCHER_ID, rs.result().getBatchVoucherId());
+        promise.complete(tx);
+      }
+    });
+    return promise.future();
+  }
+}

--- a/src/main/java/org/folio/service/BatchVoucherService.java
+++ b/src/main/java/org/folio/service/BatchVoucherService.java
@@ -1,0 +1,59 @@
+package org.folio.service;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.folio.rest.util.ResponseUtils.handleNoContentResponse;
+
+import com.google.common.collect.ImmutableMap;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Tx;
+
+public class BatchVoucherService {
+
+  private static final String BATCH_VOUCHER_ID = "batchVoucherId";
+  private static final String BATCH_VOUCHERS_TABLE = "batch_vouchers";
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private PostgresClient pgClient;
+
+  public BatchVoucherService(PostgresClient pgClient) {
+    this.pgClient = pgClient;
+  }
+
+  public void deleteBatchVoucherById(String id, Context vertxContext, Handler<AsyncResult<Response>> asyncResultHandler) {
+
+    BatchVoucherExportsService batchVoucherExportsService = new BatchVoucherExportsService(pgClient);
+
+    vertxContext.runOnContext((v) -> {
+      Tx<Map<String, String>> tx = new Tx<>(ImmutableMap.of(BATCH_VOUCHER_ID, id), pgClient);
+
+      tx.startTx()
+        .compose(batchVoucherExportsService::deleteBatchVoucherExportsByBatchVoucherId)
+        .compose(this::deleteBatchVoucherById)
+        .compose(Tx::endTx)
+        .setHandler(handleNoContentResponse(asyncResultHandler, tx, "Batch vouchers {} {} deleted"));
+    });
+  }
+
+  public Future<Tx<Map<String, String>>> deleteBatchVoucherById(Tx<Map<String, String>> tx) {
+    Promise<Tx<Map<String, String>>> promise = Promise.promise();
+
+    pgClient.delete(tx.getConnection(), BATCH_VOUCHERS_TABLE, tx.getEntity().get(BATCH_VOUCHER_ID), (rs) -> {
+      logger.info("deletion of batch voucher completed");
+      if (rs.result().getUpdated() == 0) {
+        promise.fail(new HttpStatusException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
+      } else {
+        promise.complete(tx);
+      }
+    });
+    return promise.future();
+  }
+}

--- a/src/test/java/org/folio/rest/impl/BatchVoucherExportsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/BatchVoucherExportsImplTest.java
@@ -1,0 +1,66 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.folio.rest.utils.TestEntities.BATCH_GROUP;
+import static org.folio.rest.utils.TestEntities.BATCH_VOUCHER;
+import static org.folio.rest.utils.TestEntities.BATCH_VOUCHER_EXPORTS;
+
+import java.net.MalformedURLException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.rest.utils.IsolatedTenant;
+import org.folio.rest.utils.TestData.BatchGroup;
+import org.folio.rest.utils.TestData.BatchVoucher;
+import org.folio.rest.utils.TestData.BatchVoucherExports;
+import org.junit.jupiter.api.Test;
+
+@IsolatedTenant
+class BatchVoucherExportsImplTest extends TestBase {
+
+  @Test
+  public void testDeleteShouldDeleteExportsByProvidedIdAndRelatedBatchVoucher() throws MalformedURLException {
+    givenTestData(Pair.of(BATCH_GROUP, BatchGroup.DEFAULT),
+      Pair.of(BATCH_VOUCHER, BatchVoucher.DEFAULT),
+      Pair.of(BATCH_VOUCHER_EXPORTS, BatchVoucherExports.DEFAULT));
+
+    // Check that Batch Voucher Exports has been created
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER_EXPORTS.getId())
+    .when()
+      .get(storageUrl(BATCH_VOUCHER_EXPORTS.getEndpointWithId()))
+    .then()
+      .assertThat()
+      .statusCode(200);
+
+    // Delete Batch Voucher Exports by id
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER_EXPORTS.getId())
+    .when()
+      .delete(storageUrl(BATCH_VOUCHER_EXPORTS.getEndpointWithId()))
+    .then()
+      .assertThat()
+      .statusCode(204);
+
+    // Check that BatchVoucherExports has been deleted
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER_EXPORTS.getId())
+      .when()
+      .get(storageUrl(BATCH_VOUCHER_EXPORTS.getEndpointWithId()))
+      .then()
+      .assertThat()
+      .statusCode(404);
+
+    // Check that BatchVoucher has been deleted
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER.getId())
+      .when()
+      .get(storageUrl(BATCH_VOUCHER.getEndpointWithId()))
+      .then()
+      .assertThat()
+      .statusCode(404);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/BatchVoucherTest.java
+++ b/src/test/java/org/folio/rest/impl/BatchVoucherTest.java
@@ -129,7 +129,7 @@ public class BatchVoucherTest extends TestBase {
         .get(storageUrl(BATCH_VOUCHER_ENDPOINT_WITH_ID))
     .then()
         .assertThat()
-        .statusCode(422);
+        .statusCode(400);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/BatchVoucherTest.java
+++ b/src/test/java/org/folio/rest/impl/BatchVoucherTest.java
@@ -2,11 +2,19 @@ package org.folio.rest.impl;
 
 import static io.restassured.RestAssured.given;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.folio.rest.utils.TestEntities.BATCH_GROUP;
+import static org.folio.rest.utils.TestEntities.BATCH_VOUCHER;
+import static org.folio.rest.utils.TestEntities.BATCH_VOUCHER_EXPORTS;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.net.MalformedURLException;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.rest.utils.IsolatedTenant;
+import org.folio.rest.utils.TestData;
+import org.folio.rest.utils.TestData.BatchVoucher;
+import org.folio.rest.utils.TestData.BatchVoucherExports;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -121,7 +129,7 @@ public class BatchVoucherTest extends TestBase {
         .get(storageUrl(BATCH_VOUCHER_ENDPOINT_WITH_ID))
     .then()
         .assertThat()
-        .statusCode(400);
+        .statusCode(422);
   }
 
   @Test
@@ -136,6 +144,55 @@ public class BatchVoucherTest extends TestBase {
     .then()
         .assertThat()
         .statusCode(204);
+  }
+
+
+  @Test
+  @IsolatedTenant
+  public void testDeleteShouldDeleteVoucherAndRelatedExportsByProvidedId() throws MalformedURLException {
+    givenTestData(Pair.of(BATCH_GROUP, TestData.BatchGroup.DEFAULT),
+                  Pair.of(BATCH_VOUCHER, BatchVoucher.DEFAULT),
+                  Pair.of(BATCH_VOUCHER_EXPORTS, BatchVoucherExports.DEFAULT));
+
+    // Check that BatchVoucher has been created
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER.getId())
+    .when()
+      .get(storageUrl(BATCH_VOUCHER.getEndpointWithId()))
+    .then()
+      .assertThat()
+      .statusCode(200);
+
+    // Delete BatchVoucher by id
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER.getId())
+    .when()
+      .delete(storageUrl(BATCH_VOUCHER.getEndpointWithId()))
+    .then()
+      .assertThat()
+      .statusCode(204);
+
+    // Check that BatchVoucher has been deleted
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER.getId())
+    .when()
+      .get(storageUrl(BATCH_VOUCHER.getEndpointWithId()))
+    .then()
+      .assertThat()
+      .statusCode(404);
+
+    // Check that BatchVoucherExports has been deleted
+    given()
+      .spec(isolatedRequestSpec())
+      .pathParam(ID, BATCH_VOUCHER_EXPORTS.getId())
+      .when()
+      .get(storageUrl(BATCH_VOUCHER_EXPORTS.getEndpointWithId()))
+      .then()
+      .assertThat()
+      .statusCode(404);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -30,7 +30,6 @@ class EntitiesCrudTest extends TestBase {
       TestEntities.INVOICE,
       TestEntities.BATCH_VOUCHER_EXPORT_CONFIGS,
       TestEntities.BATCH_VOUCHER_EXPORTS,
-      TestEntities.BATCH_VOUCHER,
       TestEntities.BATCH_GROUP);
   }
 
@@ -148,7 +147,9 @@ class EntitiesCrudTest extends TestBase {
 
   @ParameterizedTest
   @Order(9)
-  @EnumSource(TestEntities.class)
+  @EnumSource(value = TestEntities.class,
+    names = {"BATCH_VOUCHER"},
+    mode = EnumSource.Mode.EXCLUDE)
   void testVerifyDelete(TestEntities testEntity) throws MalformedURLException {
     logger.info(String.format("--- mod-invoice-storages %s test: Verify %s is deleted with ID: %s", testEntity.name(),
         testEntity.name(), testEntity.getId()));

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -131,5 +131,7 @@ public class StorageTestSuite {
   @Nested
   class BatchVoucherTestNested extends BatchVoucherTest{}
   @Nested
+  class BatchVoucherExportsTestNested extends BatchVoucherExportsImplTest{}
+  @Nested
   class VoucherNumberTestNested extends VoucherNumberTest {}
 }

--- a/src/test/java/org/folio/rest/utils/IsolatedTenant.java
+++ b/src/test/java/org/folio/rest/utils/IsolatedTenant.java
@@ -1,0 +1,16 @@
+package org.folio.rest.utils;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({TYPE, METHOD, ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(IsolatedTenantExtension.class)
+public @interface IsolatedTenant {
+}

--- a/src/test/java/org/folio/rest/utils/IsolatedTenantExtension.java
+++ b/src/test/java/org/folio/rest/utils/IsolatedTenantExtension.java
@@ -1,0 +1,47 @@
+package org.folio.rest.utils;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
+import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+
+import io.restassured.http.Header;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class IsolatedTenantExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+  private final Logger logger = LoggerFactory.getLogger(IsolatedTenantExtension.class);
+  private static final String ISOLATED_TENANT = "isolated";
+
+  @Override
+  public void beforeTestExecution(ExtensionContext context) throws Exception {
+    if (hasTenantAnnotationClassOrMethod(context)) {
+      final Header TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, ISOLATED_TENANT);
+
+      prepareTenant(TENANT_HEADER, false);
+      logger.info("Isolated tenant has been prepared");
+    }
+  }
+
+  @Override
+  public void afterTestExecution(ExtensionContext context) throws Exception {
+    if (hasTenantAnnotationClassOrMethod(context)) {
+      final Header TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, ISOLATED_TENANT);
+
+      deleteTenant(TENANT_HEADER);
+      logger.info("Isolated tenant has been deleted");
+
+    }
+  }
+
+  private Boolean hasTenantAnnotationClassOrMethod(ExtensionContext context) {
+    return
+      context.getElement().map(el -> ((Method)el).getDeclaringClass().isAnnotationPresent(IsolatedTenant.class)).orElse(false)
+        || context.getElement().map(el -> isAnnotated(el, IsolatedTenant.class)).orElse(false);
+  }
+}

--- a/src/test/java/org/folio/rest/utils/TestData.java
+++ b/src/test/java/org/folio/rest/utils/TestData.java
@@ -1,0 +1,36 @@
+package org.folio.rest.utils;
+
+public class TestData {
+
+  public interface Invoice {
+    String DEFAULT = "data/invoices/123invoicenumber45_approved_for_2_orders.json";
+  }
+
+  public interface InvoiceLines {
+    String DEFAULT = "data/invoice-lines/123invoicenumber45-1.json";
+  }
+
+  public interface Voucher {
+    String DEFAULT = "data/vouchers/test_voucher.json";
+  }
+
+  public interface VoucherLines {
+    String DEFAULT = "data/voucher-lines/test_voucher_line.json";
+  }
+
+  public interface BatchGroup {
+    String DEFAULT = "data/batch-groups/test-batch-group.json";
+  }
+
+  public interface BatchVoucherExportConfigs {
+    String DEFAULT = "data/batch-voucher-export-configs/test_config.json";
+  }
+
+  public interface BatchVoucher {
+    String DEFAULT = "data/batch-voucher-exports/batch-vouchers/test-batch-voucher.json";
+  }
+
+  public interface BatchVoucherExports {
+    String DEFAULT = "data/batch-voucher-exports/test-batch-voucher-export.json";
+  }
+}

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -7,16 +7,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum TestEntities {
-  INVOICE("/invoice-storage/invoices", Invoice.class, "invoices/123invoicenumber45_approved_for_2_orders.json", "note", "Updated note for invoice", 8, 0, true),
-  INVOICE_LINES("/invoice-storage/invoice-lines", InvoiceLine.class, "invoice-lines/123invoicenumber45-1.json", "quantity", 5, 9, 0, true),
-  VOUCHER("/voucher-storage/vouchers", Voucher.class, "vouchers/test_voucher.json", "exportToAccounting", true, 1, 0, true),
-  VOUCHER_LINES("/voucher-storage/voucher-lines", VoucherLine.class, "voucher-lines/test_voucher_line.json", "externalAccountNumber", "Comment from unit test", 1, 0, true),
-  BATCH_GROUP("/batch-group-storage/batch-groups", BatchGroup.class, "batch-groups/test-batch-group.json", "name", "folio", 2, 1, true),
-  BATCH_VOUCHER_EXPORT_CONFIGS("/batch-voucher-storage/export-configurations", ExportConfig.class, "batch-voucher-export-configs/test_config.json", "enableScheduledExport", false, 0, 0, true),
-  BATCH_VOUCHER("/batch-voucher-storage/batch-vouchers", BatchVoucher.class, "batch-voucher-exports/batch-vouchers/test-batch-voucher.json", "batchGroup", null, 0, 0, false),
-  BATCH_VOUCHER_EXPORTS("/batch-voucher-storage/batch-voucher-exports", BatchVoucherExport.class, "batch-voucher-exports/test-batch-voucher-export.json", "message", "test", 0, 0, true);
-
-  private static final String SAMPLES_PATH = "data/";
+  INVOICE("/invoice-storage/invoices", Invoice.class, TestData.Invoice.DEFAULT, "note", "Updated note for invoice", 8, 0, true),
+  INVOICE_LINES("/invoice-storage/invoice-lines", InvoiceLine.class, TestData.InvoiceLines.DEFAULT, "quantity", 5, 9, 0, true),
+  VOUCHER("/voucher-storage/vouchers", Voucher.class, TestData.Voucher.DEFAULT, "exportToAccounting", true, 1, 0, true),
+  VOUCHER_LINES("/voucher-storage/voucher-lines", VoucherLine.class, TestData.VoucherLines.DEFAULT, "externalAccountNumber", "Comment from unit test", 1, 0, true),
+  BATCH_GROUP("/batch-group-storage/batch-groups", BatchGroup.class, TestData.BatchGroup.DEFAULT, "name", "folio", 2, 1, true),
+  BATCH_VOUCHER_EXPORT_CONFIGS("/batch-voucher-storage/export-configurations", ExportConfig.class, TestData.BatchVoucherExportConfigs.DEFAULT, "enableScheduledExport", false, 0, 0, true),
+  BATCH_VOUCHER("/batch-voucher-storage/batch-vouchers", BatchVoucher.class, TestData.BatchVoucher.DEFAULT, "batchGroup", null, 0, 0, false),
+  BATCH_VOUCHER_EXPORTS("/batch-voucher-storage/batch-voucher-exports", BatchVoucherExport.class, TestData.BatchVoucherExports.DEFAULT, "message", "test", 0, 0, true);
 
   TestEntities(String endpoint, Class<?> clazz, String sampleFileName, String updatedFieldName, Object updatedFieldValue, int initialQuantity, int systemDataQuantity, boolean collection) {
     this.endpoint = endpoint;
@@ -48,7 +46,7 @@ public enum TestEntities {
   }
 
   public String getSampleFileName() {
-    return SAMPLES_PATH + sampleFileName;
+    return sampleFileName;
   }
 
   public String getUpdatedFieldName() {


### PR DESCRIPTION
## Purpose
- Implement cascade deletion for BatchVoucher and BatchVoucherExports
## Approach
- BatchVoucherService and BatchVoucherExportsService has been implemented to add cascade deletion
- Tests has been added
- Add Isolated tenant approach for tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
