### PR TITLE
Created GIN index for fields that are producing WARN…

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -157,6 +157,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "releaseEncumbrance",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
         }
       ]
     },


### PR DESCRIPTION
… messages

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODINVOSTO-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." 
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODINVOSTO-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->
this logs can be seen 249 times
`[mod_invoice_storage] WARN  CQL2PgJSON           Doing LIKE search without index for invoice_lines.jsonb->>'releaseEncumbrance', CQL >>> SQL: releaseEncumbrance == true >>> lower(f_unaccent(invoice_lines.jsonb->>'releaseEncumbrance')) LIKE lower(f_unaccent('true'))`
![image](https://github.com/folio-org/mod-invoice-storage/assets/113523904/e4f1381d-b343-4059-82f9-b9d1953d7bf8)


## Learning
GIN is more appropriate for jsonb columns
https://pganalyze.com/blog/gin-index
