### PR TITLE
[MODINVOSTO-182]. Override exactCount for a precise totalCount

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,4 +1,5 @@
 {
+  "exactCount" : 100000,
   "scripts": [
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,5 +1,5 @@
 {
-  "exactCount" : 100000,
+  "exactCount" : 50000,
   "scripts": [
     {
       "run": "after",


### PR DESCRIPTION
## Purpose

- Records count on the UI is being displayed as an estimate, which is imprecise and cause confusion. This small PR will improve precision of the returned `totalCount` from all endpoints on mod-invoice-storage

## Approach

- Override default `exactCount` from default 1k to 50k

## Related Issues

Speedup invoices filtering/sorting performance on big datasets [[MODINVOSTO-182]](<https://folio-org.atlassian.net/browse/MODINVOSTO-182>)