### PR TITLE
[MODINVOSTO-IDX-FIX]. Remove faulty invoices_no_acq_unit index

### DIFF
--- a/src/main/resources/templates/db_scripts/invoices_table.sql
+++ b/src/main/resources/templates/db_scripts/invoices_table.sql
@@ -9,6 +9,3 @@ CREATE INDEX IF NOT EXISTS invoices_status_sort ON ${myuniversity}_${mymodule}.i
 
 CREATE INDEX IF NOT EXISTS invoices_invoice_total_sort ON ${myuniversity}_${mymodule}.invoices
   (left(lower(f_unaccent(invoices.jsonb->>'invoiceTotal')),600), lower(f_unaccent(invoices.jsonb->>'invoiceTotal')));
-
-CREATE INDEX IF NOT EXISTS invoices_no_acq_unit ON ${myuniversity}_${mymodule}.invoices(jsonb)
-  WHERE left(lower(f_unaccent(jsonb ->> 'acqUnitIds')), 600) NOT LIKE '[]';


### PR DESCRIPTION
## Purpose

- Remove faulty invoices_no_acq_unit index that breaks installation in older versions of PG DB (v12)
- The actual issue was detected in mod-orders-storage with an analogous purchase_order_no_acq_unit custom index 

## Approach

- Remove custom the index from the installation script
