### PR TITLE
[MODINVOSTO-187] Implement audit outbox pattern for sending kafka events about invoice updates

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -717,7 +717,9 @@
       { "name": "DB_DATABASE", "value": "okapi_modules" },
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
-      { "name": "DB_MAXPOOLSIZE", "value": "5" }
+      { "name": "DB_MAXPOOLSIZE", "value": "5" },
+      { "name": "KAFKA_HOST", "value": "10.0.2.15" },
+      { "name": "KAFKA_PORT", "value": "9092" }
     ]
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -338,6 +338,20 @@
           "permissionsRequired": ["batch-group-storage.batch-groups.item.delete"]
         }
       ]
+    },
+    {
+      "id": "_timer",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": ["POST"],
+          "pathPattern": "/invoice-storage/audit-outbox/process",
+          "modulePermissions": [],
+          "unit": "minute",
+          "delay": "30"
+        }
+      ]
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
     <!--Dependency Management Properties-->
     <vertx.version>4.5.10</vertx.version>
+    <kafkaclients.version>3.6.1</kafkaclients.version>
     <log4j.version>2.24.1</log4j.version>
 
     <!--Folio dependencies properties-->
@@ -182,6 +183,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafkaclients.version}</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,10 @@
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>false</showWeaveInfo>
           <forceAjcCompile>true</forceAjcCompile>
+          <includes>
+            <include>**/impl/*.java</include>
+            <include>**/*.aj</include>
+          </includes>
           <aspectLibraries>
             <aspectLibrary>
               <groupId>org.folio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
     <!--Folio dependencies properties-->
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
+    <folio-kafka-wrapper.version>3.1.1</folio-kafka-wrapper.version>
 
     <!--Dependency properties-->
     <aspectj.version>1.9.22.1</aspectj.version>
@@ -155,6 +156,16 @@
       <artifactId>postgres-testing</artifactId>
       <version>${raml-module-builder.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-kafka-wrapper</artifactId>
+      <version>${folio-kafka-wrapper.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-kafka-client</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <!--Folio dependencies properties-->
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
-    <folio-kafka-wrapper.version>3.1.1</folio-kafka-wrapper.version>
+    <folio-kafka-wrapper.version>3.2.0</folio-kafka-wrapper.version>
 
     <!--Dependency properties-->
     <aspectj.version>1.9.22.1</aspectj.version>
@@ -182,6 +182,30 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.mguenther.kafka</groupId>
+      <artifactId>kafka-junit</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sf.jopt-simple</groupId>
+          <artifactId>jopt-simple</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.13</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/ramls/audit-outbox.raml
+++ b/ramls/audit-outbox.raml
@@ -9,11 +9,10 @@ documentation:
     content: This API is intended for internal use only by the Timer interface
 
 types:
-  event-action: !include acq-models/mod-invoice-storage/schemas/event_action.json
-  event-topic: !include acq-models/mod-invoice-storage/schemas/event_topic.json
   outbox-event-log: !include acq-models/mod-invoice-storage/schemas/outbox_event_log.json
   invoice-audit-event: !include acq-models/mod-invoice-storage/schemas/invoice_audit_event.json
   invoice-line-audit-event: !include acq-models/mod-invoice-storage/schemas/invoice_line_audit_event.json
+  event-topic: !include acq-models/mod-invoice-storage/schemas/event_topic.json
 
 /invoice-storage/audit-outbox:
   /process:

--- a/ramls/audit-outbox.raml
+++ b/ramls/audit-outbox.raml
@@ -9,7 +9,11 @@ documentation:
     content: This API is intended for internal use only by the Timer interface
 
 types:
-  outbox-event-log: !include acq-models/mod-orders-storage/schemas/outbox_event_log.json
+  event-action: !include acq-models/mod-invoice-storage/schemas/event_action.json
+  event-topic: !include acq-models/mod-invoice-storage/schemas/event_topic.json
+  outbox-event-log: !include acq-models/mod-invoice-storage/schemas/outbox_event_log.json
+  invoice-audit-event: !include acq-models/mod-invoice-storage/schemas/invoice_audit_event.json
+  invoice-line-audit-event: !include acq-models/mod-invoice-storage/schemas/invoice_line_audit_event.json
 
 /invoice-storage/audit-outbox:
   /process:

--- a/ramls/audit-outbox.raml
+++ b/ramls/audit-outbox.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0
+title: Audit outbox API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://github.com/folio-org/mod-invoice-storage
+
+documentation:
+  - title: Audit outbox API
+    content: This API is intended for internal use only by the Timer interface
+
+types:
+  outbox-event-log: !include acq-models/mod-orders-storage/schemas/outbox_event_log.json
+
+/invoice-storage/audit-outbox:
+  /process:
+    post:
+      description: Read audit events from DB and send them to Kafka

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,17 +1,27 @@
 package org.folio.config;
 
+import org.folio.dao.audit.AuditOutboxEventLogDAO;
+import org.folio.dao.audit.AuditOutboxEventLogPostgresDAO;
 import org.folio.dao.invoice.InvoiceDAO;
 import org.folio.dao.invoice.InvoicePostgresDAO;
 import org.folio.dao.lines.InvoiceLinesDAO;
 import org.folio.dao.lines.InvoiceLinesPostgresDAO;
+import org.folio.dao.lock.InternalLockDAO;
+import org.folio.dao.lock.InternalLockPostgresDAO;
+import org.folio.kafka.KafkaConfig;
 import org.folio.rest.core.RestClient;
 import org.folio.service.InvoiceLineNumberService;
+import org.folio.service.InvoiceLineStorageService;
 import org.folio.service.InvoiceStorageService;
+import org.folio.service.audit.AuditEventProducer;
+import org.folio.service.audit.AuditOutboxService;
 import org.folio.service.order.OrderStorageService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import(KafkaConfiguration.class)
 public class ApplicationConfig {
 
   @Bean
@@ -34,12 +44,38 @@ public class ApplicationConfig {
   }
 
   @Bean
-  public InvoiceStorageService invoiceStorageService(InvoiceDAO invoiceDAO) {
-    return new InvoiceStorageService(invoiceDAO);
+  public AuditOutboxEventLogDAO auditOutboxEventLogDAO() {
+    return new AuditOutboxEventLogPostgresDAO();
+  }
+
+  @Bean
+  public InternalLockDAO internalLockDAO() {
+    return new InternalLockPostgresDAO();
+  }
+
+  @Bean
+  public InvoiceStorageService invoiceStorageService(InvoiceDAO invoiceDAO, AuditOutboxService auditOutboxService) {
+    return new InvoiceStorageService(invoiceDAO, auditOutboxService);
+  }
+
+  @Bean
+  public InvoiceLineStorageService invoiceLineStorageService(InvoiceLinesDAO invoiceLinesDAO, AuditOutboxService auditOutboxService) {
+    return new InvoiceLineStorageService(invoiceLinesDAO, auditOutboxService);
   }
 
   @Bean
   public InvoiceLineNumberService invoiceLineNumberService(InvoiceDAO invoiceDAO, InvoiceLinesDAO invoiceLinesDAO) {
     return new InvoiceLineNumberService(invoiceDAO, invoiceLinesDAO);
   }
+
+  @Bean
+  public AuditEventProducer auditEventProducer(KafkaConfig kafkaConfig) {
+    return new AuditEventProducer(kafkaConfig);
+  }
+
+  @Bean
+  public AuditOutboxService auditOutboxService(AuditOutboxEventLogDAO auditOutboxEventLogDAO, InternalLockDAO internalLockDAO, AuditEventProducer producer) {
+    return new AuditOutboxService(auditOutboxEventLogDAO, internalLockDAO, producer);
+  }
+
 }

--- a/src/main/java/org/folio/config/KafkaConfiguration.java
+++ b/src/main/java/org/folio/config/KafkaConfiguration.java
@@ -1,0 +1,36 @@
+package org.folio.config;
+
+import org.folio.kafka.KafkaConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KafkaConfiguration {
+
+  @Value("${KAFKA_HOST:kafka}")
+  private String kafkaHost;
+  @Value("${KAFKA_PORT:9092}")
+  private String kafkaPort;
+  @Value("${OKAPI_URL:http://okapi:9130}")
+  private String okapiUrl;
+  @Value("${REPLICATION_FACTOR:1}")
+  private int replicationFactor;
+  @Value("${MAX_REQUEST_SIZE:1048576}")
+  private int maxRequestSize;
+  @Value("${ENV:folio}")
+  private String envId;
+
+  @Bean
+  public KafkaConfig kafkaConfig() {
+    return KafkaConfig.builder()
+      .envId(envId)
+      .kafkaHost(kafkaHost)
+      .kafkaPort(kafkaPort)
+      .okapiUrl(okapiUrl)
+      .replicationFactor(replicationFactor)
+      .maxRequestSize(maxRequestSize)
+      .build();
+  }
+
+}

--- a/src/main/java/org/folio/dao/DbUtils.java
+++ b/src/main/java/org/folio/dao/DbUtils.java
@@ -1,6 +1,12 @@
 package org.folio.dao;
 
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+
+import io.vertx.core.Future;
+import io.vertx.ext.web.handler.HttpException;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 
 public class DbUtils {
 
@@ -8,6 +14,12 @@ public class DbUtils {
 
   public static String getTenantTableName(String tenantId, String tableName) {
     return TABLE_NAME_TEMPLATE.formatted(convertToPsqlStandard(tenantId), tableName);
+  }
+
+  public static Future<Void> verifyEntityUpdate(RowSet<Row> updated) {
+    return updated.rowCount() == 1
+      ? Future.succeededFuture()
+      : Future.failedFuture(new HttpException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
   }
 
 }

--- a/src/main/java/org/folio/dao/DbUtils.java
+++ b/src/main/java/org/folio/dao/DbUtils.java
@@ -22,4 +22,6 @@ public class DbUtils {
       : Future.failedFuture(new HttpException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
   }
 
+  private DbUtils() {}
+
 }

--- a/src/main/java/org/folio/dao/DbUtils.java
+++ b/src/main/java/org/folio/dao/DbUtils.java
@@ -1,0 +1,13 @@
+package org.folio.dao;
+
+import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+
+public class DbUtils {
+
+  private static final String TABLE_NAME_TEMPLATE = "%s.%s";
+
+  public static String getTenantTableName(String tenantId, String tableName) {
+    return TABLE_NAME_TEMPLATE.formatted(convertToPsqlStandard(tenantId), tableName);
+  }
+
+}

--- a/src/main/java/org/folio/dao/audit/AuditOutboxEventLogDAO.java
+++ b/src/main/java/org/folio/dao/audit/AuditOutboxEventLogDAO.java
@@ -11,7 +11,7 @@ public interface AuditOutboxEventLogDAO {
 
   Future<List<OutboxEventLog>> getEventLogs(Conn conn, String tenantId);
 
-  Future<String> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId);
+  Future<Void> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId);
 
   Future<Integer> deleteEventLogs(Conn conn, List<String> eventIds, String tenantId);
 

--- a/src/main/java/org/folio/dao/audit/AuditOutboxEventLogDAO.java
+++ b/src/main/java/org/folio/dao/audit/AuditOutboxEventLogDAO.java
@@ -1,0 +1,18 @@
+package org.folio.dao.audit;
+
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.OutboxEventLog;
+import org.folio.rest.persist.Conn;
+
+import io.vertx.core.Future;
+
+public interface AuditOutboxEventLogDAO {
+
+  Future<List<OutboxEventLog>> getEventLogs(Conn conn, String tenantId);
+
+  Future<String> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId);
+
+  Future<Integer> deleteEventLogs(Conn conn, List<String> eventIds, String tenantId);
+
+}

--- a/src/main/java/org/folio/dao/audit/AuditOutboxEventLogPostgresDAO.java
+++ b/src/main/java/org/folio/dao/audit/AuditOutboxEventLogPostgresDAO.java
@@ -7,20 +7,22 @@ import java.util.UUID;
 
 import org.folio.rest.jaxrs.model.OutboxEventLog;
 import org.folio.rest.persist.Conn;
-import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.Criteria.Limit;
-import org.folio.rest.persist.interfaces.Results;
+import org.folio.service.util.OutboxEventFields;
 
 import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Tuple;
 import lombok.extern.log4j.Log4j2;
+import one.util.streamex.StreamEx;
 
 @Log4j2
 public class AuditOutboxEventLogPostgresDAO implements AuditOutboxEventLogDAO {
 
   public static final String OUTBOX_TABLE_NAME = "outbox_event_log";
-  private static final String BATCH_DELETE = "DELETE from %s where event_id = ANY ($1)";
+  private static final String SELECT_SQL = "SELECT * FROM %s LIMIT 1000";
+  private static final String INSERT_SQL = "INSERT INTO %s (event_id, entity_type, action, payload) VALUES ($1, $2, $3, $4)";
+  private static final String BATCH_DELETE_SQL = "DELETE from %s where event_id = ANY ($1)";
 
   /**
    * Get all event logs from outbox table.
@@ -32,8 +34,8 @@ public class AuditOutboxEventLogPostgresDAO implements AuditOutboxEventLogDAO {
   public Future<List<OutboxEventLog>> getEventLogs(Conn conn, String tenantId) {
     log.trace("getEventLogs:: Fetching event logs from outbox table for tenantId: '{}'", tenantId);
     var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
-    return conn.get(tableName, OutboxEventLog.class, new Criterion().setLimit(new Limit(1000)))
-      .map(Results::getResults)
+    return conn.execute(SELECT_SQL.formatted(tableName))
+      .map(rows -> StreamEx.of(rows.iterator()).map(this::convertDbRowToOutboxEventLog).toList())
       .onFailure(t -> log.warn("getEventLogs:: Failed to fetch event logs for tenantId: '{}'", tenantId, t));
   }
 
@@ -45,11 +47,13 @@ public class AuditOutboxEventLogPostgresDAO implements AuditOutboxEventLogDAO {
    * @param tenantId the tenant id
    * @return future of id of the inserted entity
    */
-  public Future<String> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId) {
+  public Future<Void> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId) {
     log.debug("saveEventLog:: Saving event log to outbox table with eventId: '{}'", eventLog.getEventId());
     var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
-    return conn.save(tableName, eventLog)
-      .onFailure(t -> log.warn("saveEventLog:: Failed to save event log with id: '{}'", eventLog.getEventId(), t));
+    Tuple params = Tuple.of(eventLog.getEventId(), eventLog.getEntityType().value(), eventLog.getAction(), eventLog.getPayload());
+    return conn.execute(INSERT_SQL.formatted(tableName), params)
+      .onFailure(t -> log.warn("saveEventLog:: Failed to save event log with id: '{}'", eventLog.getEventId(), t))
+      .mapEmpty();
   }
 
   /**
@@ -64,9 +68,17 @@ public class AuditOutboxEventLogPostgresDAO implements AuditOutboxEventLogDAO {
     log.debug("deleteEventLogs:: Deleting outbox logs by event ids in batch: '{}'", eventIds);
     var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
     var param = eventIds.stream().map(UUID::fromString).toArray(UUID[]::new);
-    return conn.execute(BATCH_DELETE.formatted(tableName), Tuple.of(param))
+    return conn.execute(BATCH_DELETE_SQL.formatted(tableName), Tuple.of(param))
       .map(SqlResult::rowCount)
       .onFailure(t -> log.warn("deleteEventLogs: Failed to delete event logs by ids: '{}'", eventIds, t));
+  }
+
+  private OutboxEventLog convertDbRowToOutboxEventLog(Row row) {
+    return new OutboxEventLog()
+      .withEventId(row.getUUID(OutboxEventFields.EVENT_ID.getName()).toString())
+      .withEntityType(OutboxEventLog.EntityType.fromValue(row.getString(OutboxEventFields.ENTITY_TYPE.getName())))
+      .withAction(row.getString(OutboxEventFields.ACTION.getName()))
+      .withPayload(row.getString(OutboxEventFields.PAYLOAD.getName()));
   }
 
 }

--- a/src/main/java/org/folio/dao/audit/AuditOutboxEventLogPostgresDAO.java
+++ b/src/main/java/org/folio/dao/audit/AuditOutboxEventLogPostgresDAO.java
@@ -1,0 +1,72 @@
+package org.folio.dao.audit;
+
+import static org.folio.dao.DbUtils.getTenantTableName;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.rest.jaxrs.model.OutboxEventLog;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.interfaces.Results;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.Tuple;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class AuditOutboxEventLogPostgresDAO implements AuditOutboxEventLogDAO {
+
+  public static final String OUTBOX_TABLE_NAME = "outbox_event_log";
+  private static final String BATCH_DELETE = "DELETE from %s where event_id = ANY ($1)";
+
+  /**
+   * Get all event logs from outbox table.
+   *
+   * @param conn     the sql connection from transaction
+   * @param tenantId the tenant id
+   * @return future of a list of fetched event logs
+   */
+  public Future<List<OutboxEventLog>> getEventLogs(Conn conn, String tenantId) {
+    log.trace("getEventLogs:: Fetching event logs from outbox table for tenantId: '{}'", tenantId);
+    var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
+    return conn.get(tableName, OutboxEventLog.class, new Criterion().setLimit(new Limit(1000)))
+      .map(Results::getResults)
+      .onFailure(t -> log.warn("getEventLogs:: Failed to fetch event logs for tenantId: '{}'", tenantId, t));
+  }
+
+  /**
+   * Saves event log to outbox table.
+   *
+   * @param conn     the sql connection from transaction
+   * @param eventLog the event log to save
+   * @param tenantId the tenant id
+   * @return future of id of the inserted entity
+   */
+  public Future<String> saveEventLog(Conn conn, OutboxEventLog eventLog, String tenantId) {
+    log.debug("saveEventLog:: Saving event log to outbox table with eventId: '{}'", eventLog.getEventId());
+    var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
+    return conn.save(tableName, eventLog)
+      .onFailure(t -> log.warn("saveEventLog:: Failed to save event log with id: '{}'", eventLog.getEventId(), t));
+  }
+
+  /**
+   * Deletes outbox logs by event ids in batch.
+   *
+   * @param conn     the sql connection from transaction
+   * @param eventIds the event ids to delete
+   * @param tenantId the tenant id
+   * @return future of row count for deleted records
+   */
+  public Future<Integer> deleteEventLogs(Conn conn, List<String> eventIds, String tenantId) {
+    log.debug("deleteEventLogs:: Deleting outbox logs by event ids in batch: '{}'", eventIds);
+    var tableName = getTenantTableName(tenantId, OUTBOX_TABLE_NAME);
+    var param = eventIds.stream().map(UUID::fromString).toArray(UUID[]::new);
+    return conn.execute(BATCH_DELETE.formatted(tableName), Tuple.of(param))
+      .map(SqlResult::rowCount)
+      .onFailure(t -> log.warn("deleteEventLogs: Failed to delete event logs by ids: '{}'", eventIds, t));
+  }
+
+}

--- a/src/main/java/org/folio/dao/invoice/InvoiceDAO.java
+++ b/src/main/java/org/folio/dao/invoice/InvoiceDAO.java
@@ -11,7 +11,7 @@ public interface InvoiceDAO {
 
   Future<Invoice> getInvoiceByIdForUpdate(String invoiceId, Conn conn);
   Future<String> createInvoice(Invoice invoice, Conn conn);
-  Future<Void> updateInvoice(Invoice invoice, Conn conn);
+  Future<Void> updateInvoice(String id, Invoice invoice, Conn conn);
   Future<DBClient> deleteInvoice(String id, DBClient client);
   Future<DBClient> deleteInvoiceLinesByInvoiceId(String id, DBClient client);
   Future<DBClient> deleteInvoiceDocumentsByInvoiceId(String id, DBClient client);

--- a/src/main/java/org/folio/dao/invoice/InvoiceDAO.java
+++ b/src/main/java/org/folio/dao/invoice/InvoiceDAO.java
@@ -10,7 +10,7 @@ import io.vertx.core.Future;
 public interface InvoiceDAO {
 
   Future<Invoice> getInvoiceByIdForUpdate(String invoiceId, Conn conn);
-  Future<DBClient> createInvoice(Invoice invoice, DBClient client);
+  Future<String> createInvoice(Invoice invoice, Conn conn);
   Future<Void> updateInvoice(Invoice invoice, Conn conn);
   Future<DBClient> deleteInvoice(String id, DBClient client);
   Future<DBClient> deleteInvoiceLinesByInvoiceId(String id, DBClient client);

--- a/src/main/java/org/folio/dao/invoice/InvoicePostgresDAO.java
+++ b/src/main/java/org/folio/dao/invoice/InvoicePostgresDAO.java
@@ -61,8 +61,8 @@ public class InvoicePostgresDAO implements InvoiceDAO {
     }
     return conn.save(INVOICE_TABLE, invoice.getId(), invoice, true)
       .recover(t -> Future.failedFuture(convertPgExceptionIfNeeded(t)))
-      .onFailure(t -> log.error("createInvoice failed for invoice with id {}", invoice.getId(), t))
-      .onSuccess(s -> log.info("createInvoice:: New invoice with id: '{}' successfully created", invoice.getId()));
+      .onSuccess(s -> log.info("createInvoice:: New invoice with id: '{}' successfully created", invoice.getId()))
+      .onFailure(t -> log.error("Failed to create invoice with id: '{}'", invoice.getId(), t));
   }
 
   @Override
@@ -70,7 +70,7 @@ public class InvoicePostgresDAO implements InvoiceDAO {
     return conn.update(INVOICE_TABLE, invoice, id)
       .compose(DbUtils::verifyEntityUpdate)
       .onSuccess(v -> log.info("updateInvoice:: Invoice with id: '{}' successfully updated", invoice.getId()))
-      .onFailure(t -> log.error("Update failed for invoice with id {}", invoice.getId(), t))
+      .onFailure(t -> log.error("Update failed for invoice with id: '{}'", invoice.getId(), t))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/dao/invoice/InvoicePostgresDAO.java
+++ b/src/main/java/org/folio/dao/invoice/InvoicePostgresDAO.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dao.DbUtils;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.rest.jaxrs.model.Contents;
 import org.folio.rest.jaxrs.model.DocumentMetadata;
@@ -65,9 +66,11 @@ public class InvoicePostgresDAO implements InvoiceDAO {
   }
 
   @Override
-  public Future<Void> updateInvoice(Invoice invoice, Conn conn) {
-    return conn.update(INVOICE_TABLE, invoice, invoice.getId())
-      .onFailure(t -> log.error("updateInvoice failed for invoice with id {}", invoice.getId(), t))
+  public Future<Void> updateInvoice(String id, Invoice invoice, Conn conn) {
+    return conn.update(INVOICE_TABLE, invoice, id)
+      .compose(DbUtils::verifyEntityUpdate)
+      .onSuccess(v -> log.info("updateInvoice:: Invoice with id: '{}' successfully updated", invoice.getId()))
+      .onFailure(t -> log.error("Update failed for invoice with id {}", invoice.getId(), t))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/dao/lines/InvoiceLinesDAO.java
+++ b/src/main/java/org/folio/dao/lines/InvoiceLinesDAO.java
@@ -8,5 +8,11 @@ import org.folio.rest.persist.Criteria.Criterion;
 import java.util.List;
 
 public interface InvoiceLinesDAO {
+
   Future<List<InvoiceLine>> getInvoiceLines(Criterion criterion, Conn conn);
+
+  Future<String> createInvoiceLine(InvoiceLine invoiceLine, Conn conn);
+
+  Future<Void> updateInvoiceLine(String id, InvoiceLine invoiceLine, Conn conn);
+
 }

--- a/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.interfaces.Results;
 
 import java.util.List;
 
@@ -16,12 +17,28 @@ public class InvoiceLinesPostgresDAO implements InvoiceLinesDAO {
 
   @Override
   public Future<List<InvoiceLine>> getInvoiceLines(Criterion criterion, Conn conn) {
-    log.trace("InvoiceLinesPostgresDAO getInvoiceLines, criterion={}", criterion);
+    log.trace("getInvoiceLines:: Getting invoice lines with criterion: {}", criterion);
     return conn.get(INVOICE_LINE_TABLE, InvoiceLine.class, criterion, false)
-      .map(results -> {
-        log.trace("getInvoiceLines success, criterion={}", criterion);
-        return results.getResults();
-      })
-      .onFailure(t -> log.error("getInvoiceLines failed, criterion={}", criterion, t));
+      .map(Results::getResults)
+      .onSuccess(lines -> log.trace("getInvoiceLines:: Got {} invoice lines with criterion: {}", lines.size(), criterion))
+      .onFailure(t -> log.error("Failed to get invoice lines with criterion: {}", criterion, t));
   }
+
+  @Override
+  public Future<String> createInvoiceLine(InvoiceLine invoiceLine, Conn conn) {
+    log.trace("createInvoiceLine:: Creating invoice line: {}", invoiceLine);
+    return conn.save(INVOICE_LINE_TABLE, invoiceLine)
+      .onSuccess(invoiceLineId -> log.info("createInvoiceLine:: Created invoice line with id: {}", invoiceLineId))
+      .onFailure(t -> log.error("Failed to create invoice line: {}", invoiceLine, t));
+  }
+
+  @Override
+  public Future<Void> updateInvoiceLine(String id, InvoiceLine invoiceLine, Conn conn) {
+    log.trace("updateInvoiceLine:: Updating invoice line: {}", invoiceLine);
+    return conn.update(INVOICE_LINE_TABLE, invoiceLine, id)
+      .onSuccess(v -> log.info("updateInvoiceLine:: Updated invoice line with id: {}", id))
+      .onFailure(t -> log.error("Failed to update invoice line with id: {}", id, t))
+      .mapEmpty();
+  }
+
 }

--- a/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
@@ -3,6 +3,7 @@ package org.folio.dao.lines;
 import io.vertx.core.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dao.DbUtils;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -11,6 +12,7 @@ import org.folio.rest.persist.interfaces.Results;
 import java.util.List;
 
 import static org.folio.rest.impl.InvoiceStorageImpl.INVOICE_LINE_TABLE;
+import static org.folio.rest.utils.ResponseUtils.convertPgExceptionIfNeeded;
 
 public class InvoiceLinesPostgresDAO implements InvoiceLinesDAO {
   private final Logger log = LogManager.getLogger();
@@ -27,7 +29,8 @@ public class InvoiceLinesPostgresDAO implements InvoiceLinesDAO {
   @Override
   public Future<String> createInvoiceLine(InvoiceLine invoiceLine, Conn conn) {
     log.trace("createInvoiceLine:: Creating invoice line: {}", invoiceLine);
-    return conn.save(INVOICE_LINE_TABLE, invoiceLine)
+    return conn.save(INVOICE_LINE_TABLE, invoiceLine.getId(), invoiceLine, true)
+      .recover(t -> Future.failedFuture(convertPgExceptionIfNeeded(t)))
       .onSuccess(invoiceLineId -> log.info("createInvoiceLine:: Created invoice line with id: {}", invoiceLineId))
       .onFailure(t -> log.error("Failed to create invoice line: {}", invoiceLine, t));
   }
@@ -36,6 +39,7 @@ public class InvoiceLinesPostgresDAO implements InvoiceLinesDAO {
   public Future<Void> updateInvoiceLine(String id, InvoiceLine invoiceLine, Conn conn) {
     log.trace("updateInvoiceLine:: Updating invoice line: {}", invoiceLine);
     return conn.update(INVOICE_LINE_TABLE, invoiceLine, id)
+      .compose(DbUtils::verifyEntityUpdate)
       .onSuccess(v -> log.info("updateInvoiceLine:: Updated invoice line with id: {}", id))
       .onFailure(t -> log.error("Failed to update invoice line with id: {}", id, t))
       .mapEmpty();

--- a/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/InvoiceLinesPostgresDAO.java
@@ -32,7 +32,7 @@ public class InvoiceLinesPostgresDAO implements InvoiceLinesDAO {
     return conn.save(INVOICE_LINE_TABLE, invoiceLine.getId(), invoiceLine, true)
       .recover(t -> Future.failedFuture(convertPgExceptionIfNeeded(t)))
       .onSuccess(invoiceLineId -> log.info("createInvoiceLine:: Created invoice line with id: {}", invoiceLineId))
-      .onFailure(t -> log.error("Failed to create invoice line: {}", invoiceLine, t));
+      .onFailure(t -> log.error("Failed to create invoice line with id: {}", invoiceLine.getId(), t));
   }
 
   @Override

--- a/src/main/java/org/folio/dao/lock/InternalLockDAO.java
+++ b/src/main/java/org/folio/dao/lock/InternalLockDAO.java
@@ -1,0 +1,11 @@
+package org.folio.dao.lock;
+
+import org.folio.rest.persist.Conn;
+
+import io.vertx.core.Future;
+
+public interface InternalLockDAO {
+
+  Future<Integer> selectWithLocking(Conn conn, String lockName, String tenantId);
+
+}

--- a/src/main/java/org/folio/dao/lock/InternalLockPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lock/InternalLockPostgresDAO.java
@@ -1,0 +1,34 @@
+package org.folio.dao.lock;
+
+import static org.folio.dao.DbUtils.getTenantTableName;
+
+import org.folio.rest.persist.Conn;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.Tuple;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class InternalLockPostgresDAO implements InternalLockDAO {
+
+  private static final String LOCK_TABLE_NAME = "internal_lock";
+  private static final String SELECT_WITH_LOCKING = "SELECT * FROM %s WHERE lock_name = $1 FOR UPDATE";
+
+  /**
+   * Performs SELECT FOR UPDATE statement in order to implement locking.
+   * Lock released after the transaction is committed.
+   *
+   * @param conn connection with active transaction
+   * @param lockName the lock name
+   * @param tenantId the tenant id
+   * @return future with 1 row if lock was acquired
+   */
+  public Future<Integer> selectWithLocking(Conn conn, String lockName, String tenantId) {
+    log.debug("selectWithLocking:: Locking row with lockName: '{}'", lockName);
+    var tableName = getTenantTableName(tenantId, LOCK_TABLE_NAME);
+    return conn.execute(SELECT_WITH_LOCKING.formatted(tableName), Tuple.of(lockName))
+      .map(SqlResult::rowCount)
+      .onFailure(t -> log.warn("selectWithLocking:: Unable to select row with lockName: '{}'", lockName, t));
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AuditOutboxAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuditOutboxAPI.java
@@ -1,0 +1,37 @@
+package org.folio.rest.impl;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import org.folio.service.audit.AuditOutboxService;
+import org.folio.rest.jaxrs.resource.InvoiceStorageAuditOutbox;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class AuditOutboxAPI implements InvoiceStorageAuditOutbox {
+
+  @Autowired
+  private AuditOutboxService auditOutboxService;
+
+  public AuditOutboxAPI() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
+  @Override
+  public void postInvoiceStorageAuditOutboxProcess(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    auditOutboxService.processOutboxEventLogs(okapiHeaders, vertxContext)
+      .onSuccess(res -> asyncResultHandler.handle(Future.succeededFuture(Response.ok().build())))
+      .onFailure(cause -> {
+        log.warn("postInvoiceStorageAuditOutboxProcess:: Processing of outbox events table has failed", cause);
+        asyncResultHandler.handle(Future.failedFuture(cause));
+      });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AuditOutboxAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuditOutboxAPI.java
@@ -13,9 +13,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
 public class AuditOutboxAPI implements InvoiceStorageAuditOutbox {
 
   @Autowired
@@ -29,9 +27,6 @@ public class AuditOutboxAPI implements InvoiceStorageAuditOutbox {
   public void postInvoiceStorageAuditOutboxProcess(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     auditOutboxService.processOutboxEventLogs(okapiHeaders, vertxContext)
       .onSuccess(res -> asyncResultHandler.handle(Future.succeededFuture(Response.ok().build())))
-      .onFailure(cause -> {
-        log.warn("postInvoiceStorageAuditOutboxProcess:: Processing of outbox events table has failed", cause);
-        asyncResultHandler.handle(Future.failedFuture(cause));
-      });
+      .onFailure(cause -> asyncResultHandler.handle(Future.failedFuture(cause)));
   }
 }

--- a/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceStorageImpl.java
@@ -12,6 +12,7 @@ import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.jaxrs.model.InvoiceLineCollection;
 import org.folio.rest.jaxrs.resource.InvoiceStorage;
 import org.folio.rest.persist.PgUtil;
+import org.folio.service.InvoiceLineStorageService;
 import org.folio.service.InvoiceStorageService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,10 +29,13 @@ public class InvoiceStorageImpl implements InvoiceStorage {
   public static final String INVOICE_ID_FIELD_NAME = "invoiceId";
   public static final String INVOICE_LINE_TABLE = "invoice_lines";
   public static final String INVOICE_PREFIX = "/invoice-storage/invoices/";
+  public static final String INVOICE_LINES_PREFIX = "/invoice-storage/invoice-lines/";
   public static final String INVOICE_TABLE = "invoices";
 
   @Autowired
   private InvoiceStorageService invoiceStorageService;
+  @Autowired
+  private InvoiceLineStorageService invoiceLineStorageService;
 
   public InvoiceStorageImpl() {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
@@ -117,16 +121,14 @@ public class InvoiceStorageImpl implements InvoiceStorage {
   @Override
   public void postInvoiceStorageInvoiceLines(InvoiceLine entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(INVOICE_LINE_TABLE, entity, okapiHeaders, vertxContext, PostInvoiceStorageInvoiceLinesResponse.class,
-        asyncResultHandler);
+    invoiceLineStorageService.createInvoiceLine(entity, asyncResultHandler, vertxContext, okapiHeaders);
   }
 
   @Validate
   @Override
   public void putInvoiceStorageInvoiceLinesById(String id, InvoiceLine entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.put(INVOICE_LINE_TABLE, entity, id, okapiHeaders, vertxContext, PutInvoiceStorageInvoiceLinesByIdResponse.class,
-        asyncResultHandler);
+    invoiceLineStorageService.updateInvoiceLine(id, entity, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/utils/ResponseUtils.java
+++ b/src/main/java/org/folio/rest/utils/ResponseUtils.java
@@ -4,6 +4,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import java.net.URI;
@@ -52,7 +53,7 @@ public class ResponseUtils {
   public static Throwable convertPgExceptionIfNeeded(Throwable cause) {
     var badRequestMessage = PgExceptionUtil.badRequestMessage(cause);
     if (badRequestMessage != null) {
-      return new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), badRequestMessage);
+      return new HttpException(BAD_REQUEST.getStatusCode(), badRequestMessage);
     } else {
       return new HttpException(INTERNAL_SERVER_ERROR.getStatusCode(), cause.getMessage());
     }
@@ -83,6 +84,10 @@ public class ResponseUtils {
 
   public static Future<Response> buildOkResponse(Object body) {
     return Future.succeededFuture(Response.ok(body, APPLICATION_JSON).build());
+  }
+
+  public static Future<Response> buildBadRequestResponse(String body) {
+    return Future.succeededFuture(buildErrorResponse(BAD_REQUEST.getStatusCode(), body));
   }
 
   public static Future<Response> buildErrorResponse(Throwable throwable) {

--- a/src/main/java/org/folio/rest/utils/ResponseUtils.java
+++ b/src/main/java/org/folio/rest/utils/ResponseUtils.java
@@ -46,12 +46,15 @@ public class ResponseUtils {
   }
 
   public static void handleFailure(Promise<?> promise, AsyncResult<?> reply) {
-    Throwable cause = reply.cause();
-    String badRequestMessage = PgExceptionUtil.badRequestMessage(cause);
+    promise.fail(convertPgExceptionIfNeeded(reply.cause()));
+  }
+
+  public static Throwable convertPgExceptionIfNeeded(Throwable cause) {
+    var badRequestMessage = PgExceptionUtil.badRequestMessage(cause);
     if (badRequestMessage != null) {
-      promise.fail(new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), badRequestMessage));
+      return new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), badRequestMessage);
     } else {
-      promise.fail(new HttpException(INTERNAL_SERVER_ERROR.getStatusCode(), cause.getMessage()));
+      return new HttpException(INTERNAL_SERVER_ERROR.getStatusCode(), cause.getMessage());
     }
   }
 

--- a/src/main/java/org/folio/service/InvoiceLineNumberService.java
+++ b/src/main/java/org/folio/service/InvoiceLineNumberService.java
@@ -69,7 +69,7 @@ public class InvoiceLineNumberService {
         log.debug("Updating invoice {} with new nextInvoiceLineNumber", invoiceId);
         int nextNumber = invoice.getNextInvoiceLineNumber();
         invoice.setNextInvoiceLineNumber(nextNumber + 1);
-        return invoiceDAO.updateInvoice(invoice, conn)
+        return invoiceDAO.updateInvoice(invoiceId, invoice, conn)
           .map(v -> nextNumber);
       })
       .map(n -> {

--- a/src/main/java/org/folio/service/InvoiceLineStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceLineStorageService.java
@@ -1,0 +1,79 @@
+package org.folio.service;
+
+import static org.folio.rest.impl.InvoiceStorageImpl.INVOICE_LINES_PREFIX;
+import static org.folio.rest.utils.ResponseUtils.buildErrorResponse;
+import static org.folio.rest.utils.ResponseUtils.buildNoContentResponse;
+import static org.folio.rest.utils.ResponseUtils.buildResponseWithLocation;
+import static org.folio.rest.utils.RestConstants.OKAPI_URL;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import org.folio.dao.lines.InvoiceLinesDAO;
+import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.rest.persist.DBClient;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.handler.HttpException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+public class InvoiceLineStorageService {
+
+  private final InvoiceLinesDAO invoiceLinesDAO;
+
+  public void createInvoiceLine(InvoiceLine invoiceLine, Handler<AsyncResult<Response>> asyncResultHandler,
+                                Context vertxContext, Map<String, String> headers) {
+    try {
+      vertxContext.runOnContext(v -> {
+        log.info("createInvoiceLine:: Creating a new invoiceLine by id: {}", invoiceLine.getId());
+        new DBClient(vertxContext, headers).getPgClient()
+          .withTrans(conn -> invoiceLinesDAO.createInvoiceLine(invoiceLine, conn))
+          .onSuccess(s -> {
+            log.info("createInvoiceLine:: Successfully created a new invoiceLine by id: {}", invoiceLine.getId());
+            asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_LINES_PREFIX + invoiceLine.getId(), invoiceLine));
+          })
+          .onFailure(f -> {
+            log.error("Error occurred while creating a new invoiceLine with id: {}", invoiceLine.getId(), f);
+            asyncResultHandler.handle(buildErrorResponse(f));
+          });
+      });
+    } catch (Exception e) {
+      log.error("Error occurred while creating a new invoiceLine with id: {}", invoiceLine.getId(), e);
+      asyncResultHandler.handle(buildErrorResponse(
+        new HttpException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+          Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
+      ));
+    }
+  }
+
+  public void updateInvoiceLine(String id, InvoiceLine invoiceLine, Map<String, String> okapiHeaders,
+                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    try {
+      vertxContext.runOnContext(v -> {
+        log.info("updateInvoiceLine:: Updating invoice line with id: {}", id);
+        new DBClient(vertxContext, okapiHeaders).getPgClient()
+          .withTrans(conn -> invoiceLinesDAO.updateInvoiceLine(id, invoiceLine, conn))
+          .onSuccess(s -> {
+            log.info("updateInvoiceLine:: Successfully updated invoice line with id: {}", id);
+            asyncResultHandler.handle(buildNoContentResponse());
+          })
+          .onFailure(f -> {
+            log.error("Error occurred while updating invoice line with id: {}", id, f);
+            asyncResultHandler.handle(buildErrorResponse(f));
+          });
+      });
+    } catch (Exception e) {
+      log.error("Error occurred while updating invoice line with id: {}", id, e);
+      asyncResultHandler.handle(buildErrorResponse(
+        new HttpException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+          Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
+      ));
+    }
+  }
+
+}

--- a/src/main/java/org/folio/service/InvoiceLineStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceLineStorageService.java
@@ -35,11 +35,12 @@ public class InvoiceLineStorageService {
     log.info("createInvoiceLine:: Creating a new invoiceLine by id: {}", invoiceLine.getId());
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceLinesDAO.createInvoiceLine(invoiceLine, conn)
+        .map(invoiceLine::withId)
         .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.CREATE, headers)))
       .onSuccess(s -> {
         log.info("createInvoiceLine:: Successfully created a new invoiceLine by id: {}", invoiceLine.getId());
-        asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_LINES_PREFIX + invoiceLine.getId(), invoiceLine));
         auditOutboxService.processOutboxEventLogs(headers, vertxContext);
+        asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_LINES_PREFIX + invoiceLine.getId(), invoiceLine));
       })
       .onFailure(f -> {
         log.error("Error occurred while creating a new invoiceLine with id: {}", invoiceLine.getId(), f);
@@ -58,8 +59,8 @@ public class InvoiceLineStorageService {
         .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.EDIT, headers)))
       .onSuccess(s -> {
         log.info("updateInvoiceLine:: Successfully updated invoice line with id: {}", id);
-        asyncResultHandler.handle(buildNoContentResponse());
         auditOutboxService.processOutboxEventLogs(headers, vertxContext);
+        asyncResultHandler.handle(buildNoContentResponse());
       })
       .onFailure(f -> {
         log.error("Error occurred while updating invoice line with id: {}", id, f);

--- a/src/main/java/org/folio/service/InvoiceLineStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceLineStorageService.java
@@ -35,11 +35,11 @@ public class InvoiceLineStorageService {
     log.info("createInvoiceLine:: Creating a new invoiceLine by id: {}", invoiceLine.getId());
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceLinesDAO.createInvoiceLine(invoiceLine, conn)
-        .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.CREATE, headers))
-        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+        .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.CREATE, headers)))
       .onSuccess(s -> {
         log.info("createInvoiceLine:: Successfully created a new invoiceLine by id: {}", invoiceLine.getId());
         asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_LINES_PREFIX + invoiceLine.getId(), invoiceLine));
+        auditOutboxService.processOutboxEventLogs(headers, vertxContext);
       })
       .onFailure(f -> {
         log.error("Error occurred while creating a new invoiceLine with id: {}", invoiceLine.getId(), f);
@@ -55,11 +55,11 @@ public class InvoiceLineStorageService {
     }
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceLinesDAO.updateInvoiceLine(id, invoiceLine, conn)
-        .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.EDIT, headers))
-        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+        .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.EDIT, headers)))
       .onSuccess(s -> {
         log.info("updateInvoiceLine:: Successfully updated invoice line with id: {}", id);
         asyncResultHandler.handle(buildNoContentResponse());
+        auditOutboxService.processOutboxEventLogs(headers, vertxContext);
       })
       .onFailure(f -> {
         log.error("Error occurred while updating invoice line with id: {}", id, f);

--- a/src/main/java/org/folio/service/InvoiceLineStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceLineStorageService.java
@@ -1,6 +1,7 @@
 package org.folio.service;
 
 import static org.folio.rest.impl.InvoiceStorageImpl.INVOICE_LINES_PREFIX;
+import static org.folio.rest.utils.ResponseUtils.buildBadRequestResponse;
 import static org.folio.rest.utils.ResponseUtils.buildErrorResponse;
 import static org.folio.rest.utils.ResponseUtils.buildNoContentResponse;
 import static org.folio.rest.utils.ResponseUtils.buildResponseWithLocation;
@@ -9,6 +10,7 @@ import static org.folio.rest.utils.RestConstants.OKAPI_URL;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.dao.lines.InvoiceLinesDAO;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.jaxrs.model.InvoiceLineAuditEvent;
@@ -18,7 +20,6 @@ import org.folio.service.audit.AuditOutboxService;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.ext.web.handler.HttpException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -49,6 +50,9 @@ public class InvoiceLineStorageService {
   public void updateInvoiceLine(String id, InvoiceLine invoiceLine, Map<String, String> headers,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     log.info("updateInvoiceLine:: Updating invoice line with id: {}", id);
+    if (StringUtils.isBlank(id)) {
+      asyncResultHandler.handle(buildBadRequestResponse("Invoice line id is required"));
+    }
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceLinesDAO.updateInvoiceLine(id, invoiceLine, conn)
         .compose(invoiceLineId -> auditOutboxService.saveInvoiceLineOutboxLog(conn, invoiceLine, InvoiceLineAuditEvent.Action.EDIT, headers))

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -75,7 +75,7 @@ public class InvoiceStorageService {
       vertxContext.runOnContext(v -> {
         log.info("putInvoiceStorageInvoicesById:: Updating invoice with id: {}", id);
         new DBClient(vertxContext, headers).getPgClient()
-          .withTrans(conn -> invoiceDAO.updateInvoice(invoice, conn)
+          .withTrans(conn -> invoiceDAO.updateInvoice(id, invoice, conn)
             .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers)))
           .onSuccess(s -> {
             log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -5,6 +5,7 @@ import static org.folio.rest.impl.InvoiceStorageImpl.DOCUMENT_TABLE;
 import static org.folio.rest.impl.InvoiceStorageImpl.INVOICE_ID_FIELD_NAME;
 import static org.folio.rest.impl.InvoiceStorageImpl.INVOICE_PREFIX;
 import static org.folio.rest.utils.HelperUtils.combineCqlExpressions;
+import static org.folio.rest.utils.ResponseUtils.buildBadRequestResponse;
 import static org.folio.rest.utils.ResponseUtils.buildOkResponse;
 import static org.folio.rest.utils.ResponseUtils.buildErrorResponse;
 import static org.folio.rest.utils.ResponseUtils.buildNoContentResponse;
@@ -63,6 +64,9 @@ public class InvoiceStorageService {
   public void putInvoiceStorageInvoicesById(String id, Invoice invoice, Map<String, String> headers,
                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     log.info("putInvoiceStorageInvoicesById:: Updating invoice with id: {}", id);
+    if (StringUtils.isBlank(id)) {
+      asyncResultHandler.handle(buildBadRequestResponse("Invoice id is required"));
+    }
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceDAO.updateInvoice(id, invoice, conn)
         .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers))

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -19,8 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.dao.invoice.InvoiceDAO;
 import org.folio.rest.jaxrs.model.Document;
 import org.folio.rest.jaxrs.model.DocumentCollection;
-import org.folio.rest.jaxrs.model.EventAction;
 import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceAuditEvent;
 import org.folio.rest.jaxrs.model.InvoiceDocument;
 import org.folio.rest.jaxrs.resource.InvoiceStorage.GetInvoiceStorageInvoicesDocumentsByIdResponse;
 import org.folio.rest.persist.DBClient;
@@ -50,7 +50,7 @@ public class InvoiceStorageService {
         log.info("postInvoiceStorageInvoices:: Creating a new invoice by id: {}", invoice.getId());
         new DBClient(vertxContext, headers).getPgClient()
           .withTrans(conn -> invoiceDAO.createInvoice(invoice, conn)
-            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, EventAction.CREATE, headers)))
+            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers)))
           .onSuccess(s -> {
             log.info("postInvoiceStorageInvoices:: Successfully created a new invoice by id: {}", invoice.getId());
             asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
@@ -76,7 +76,7 @@ public class InvoiceStorageService {
         log.info("putInvoiceStorageInvoicesById:: Updating invoice with id: {}", id);
         new DBClient(vertxContext, headers).getPgClient()
           .withTrans(conn -> invoiceDAO.updateInvoice(invoice, conn)
-            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, EventAction.EDIT, headers)))
+            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers)))
           .onSuccess(s -> {
             log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);
             asyncResultHandler.handle(buildNoContentResponse());

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -44,55 +44,37 @@ public class InvoiceStorageService {
   private final AuditOutboxService auditOutboxService;
 
   public void postInvoiceStorageInvoices(Invoice invoice, Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext, Map<String, String> headers) {
-    try {
-      vertxContext.runOnContext(v -> {
-        log.info("postInvoiceStorageInvoices:: Creating a new invoice by id: {}", invoice.getId());
-        new DBClient(vertxContext, headers).getPgClient()
-          .withTrans(conn -> invoiceDAO.createInvoice(invoice, conn)
-            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers)))
-          .onSuccess(s -> {
-            log.info("postInvoiceStorageInvoices:: Successfully created a new invoice by id: {}", invoice.getId());
-            asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
-          })
-          .onFailure(f -> {
-            log.error("Error occurred while creating a new invoice with id: {}", invoice.getId(), f);
-            asyncResultHandler.handle(buildErrorResponse(f));
-          });
+                                         Context vertxContext, Map<String, String> headers) {
+    log.info("postInvoiceStorageInvoices:: Creating a new invoice by id: {}", invoice.getId());
+    new DBClient(vertxContext, headers).getPgClient()
+      .withTrans(conn -> invoiceDAO.createInvoice(invoice, conn)
+        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers))
+        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+      .onSuccess(s -> {
+        log.info("postInvoiceStorageInvoices:: Successfully created a new invoice by id: {}", invoice.getId());
+        asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
+      })
+      .onFailure(f -> {
+        log.error("Error occurred while creating a new invoice with id: {}", invoice.getId(), f);
+        asyncResultHandler.handle(buildErrorResponse(f));
       });
-    } catch (Exception e) {
-      log.error("Error occurred while creating a new invoice with id: {}", invoice.getId(), e);
-      asyncResultHandler.handle(buildErrorResponse(
-        new HttpException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-          Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
-      ));
-    }
   }
 
   public void putInvoiceStorageInvoicesById(String id, Invoice invoice, Map<String, String> headers,
                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    try {
-      vertxContext.runOnContext(v -> {
-        log.info("putInvoiceStorageInvoicesById:: Updating invoice with id: {}", id);
-        new DBClient(vertxContext, headers).getPgClient()
-          .withTrans(conn -> invoiceDAO.updateInvoice(id, invoice, conn)
-            .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers)))
-          .onSuccess(s -> {
-            log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);
-            asyncResultHandler.handle(buildNoContentResponse());
-          })
-          .onFailure(f -> {
-            log.error("Error occurred while updating invoice with id: {}", id, f);
-            asyncResultHandler.handle(buildErrorResponse(f));
-          });
+    log.info("putInvoiceStorageInvoicesById:: Updating invoice with id: {}", id);
+    new DBClient(vertxContext, headers).getPgClient()
+      .withTrans(conn -> invoiceDAO.updateInvoice(id, invoice, conn)
+        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers))
+        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+      .onSuccess(s -> {
+        log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);
+        asyncResultHandler.handle(buildNoContentResponse());
+      })
+      .onFailure(f -> {
+        log.error("Error occurred while updating invoice with id: {}", id, f);
+        asyncResultHandler.handle(buildErrorResponse(f));
       });
-    } catch (Exception e) {
-      log.error("Error occurred while updating invoice with id: {}", invoice.getId(), e);
-      asyncResultHandler.handle(buildErrorResponse(
-        new HttpException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-          Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
-      ));
-    }
   }
 
   public void deleteInvoiceStorageInvoicesById(String id, Handler<AsyncResult<Response>> asyncResultHandler,

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -52,8 +52,8 @@ public class InvoiceStorageService {
         .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers)))
       .onSuccess(s -> {
         log.info("postInvoiceStorageInvoices:: Successfully created a new invoice by id: {}", invoice.getId());
-        asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
         auditOutboxService.processOutboxEventLogs(headers, vertxContext);
+        asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
       })
       .onFailure(f -> {
         log.error("Error occurred while creating a new invoice with id: {}", invoice.getId(), f);
@@ -72,8 +72,8 @@ public class InvoiceStorageService {
         .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers)))
       .onSuccess(s -> {
         log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);
-        asyncResultHandler.handle(buildNoContentResponse());
         auditOutboxService.processOutboxEventLogs(headers, vertxContext);
+        asyncResultHandler.handle(buildNoContentResponse());
       })
       .onFailure(f -> {
         log.error("Error occurred while updating invoice with id: {}", id, f);

--- a/src/main/java/org/folio/service/InvoiceStorageService.java
+++ b/src/main/java/org/folio/service/InvoiceStorageService.java
@@ -49,11 +49,11 @@ public class InvoiceStorageService {
     log.info("postInvoiceStorageInvoices:: Creating a new invoice by id: {}", invoice.getId());
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceDAO.createInvoice(invoice, conn)
-        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers))
-        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.CREATE, headers)))
       .onSuccess(s -> {
         log.info("postInvoiceStorageInvoices:: Successfully created a new invoice by id: {}", invoice.getId());
         asyncResultHandler.handle(buildResponseWithLocation(headers.get(OKAPI_URL), INVOICE_PREFIX + invoice.getId(), invoice));
+        auditOutboxService.processOutboxEventLogs(headers, vertxContext);
       })
       .onFailure(f -> {
         log.error("Error occurred while creating a new invoice with id: {}", invoice.getId(), f);
@@ -69,11 +69,11 @@ public class InvoiceStorageService {
     }
     new DBClient(vertxContext, headers).getPgClient()
       .withTrans(conn -> invoiceDAO.updateInvoice(id, invoice, conn)
-        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers))
-        .compose(v -> auditOutboxService.processOutboxEventLogs(headers, vertxContext)))
+        .compose(invoiceId -> auditOutboxService.saveInvoiceOutboxLog(conn, invoice, InvoiceAuditEvent.Action.EDIT, headers)))
       .onSuccess(s -> {
         log.info("putInvoiceStorageInvoicesById:: Successfully updated invoice with id: {}", id);
         asyncResultHandler.handle(buildNoContentResponse());
+        auditOutboxService.processOutboxEventLogs(headers, vertxContext);
       })
       .onFailure(f -> {
         log.error("Error occurred while updating invoice with id: {}", id, f);

--- a/src/main/java/org/folio/service/audit/AuditEventProducer.java
+++ b/src/main/java/org/folio/service/audit/AuditEventProducer.java
@@ -29,10 +29,10 @@ public class AuditEventProducer {
   private final KafkaConfig kafkaConfig;
 
   /**
-   * Sends event for order change(Create, Edit, Delete) to kafka.
-   * OrderId is used as partition key to send all events for particular order to the same partition.
+   * Sends event for invoice change(Create, Edit) to kafka.
+   * InvoiceId is used as partition key to send all events for particular invoice to the same partition.
    *
-   * @param order        the event payload
+   * @param invoice      the event payload
    * @param eventAction  the event action
    * @param okapiHeaders the okapi headers
    * @return future with true if sending was success or failed future in another case
@@ -44,8 +44,17 @@ public class AuditEventProducer {
       .onFailure(t -> log.warn("sendInvoiceEvent:: Failed to send event with id: {} and invoiceId: {} to Kafka", event.getId(), invoice.getId(), t));
   }
 
-  public Future<Void> sendInvoiceLineEvent(InvoiceLine invoiceLine, InvoiceLineAuditEvent.Action action, Map<String, String> okapiHeaders) {
-    var event = getAuditEvent(invoiceLine, action);
+  /**
+   * Sends event for invoice line change(Create, Edit) to kafka.
+   * InvoiceLineId is used as partition key to send all events for particular invoice line to the same partition.
+   *
+   * @param invoiceLine  the event payload
+   * @param eventAction  the event action
+   * @param okapiHeaders the okapi headers
+   * @return future with true if sending was success or failed future in another case
+   */
+  public Future<Void> sendInvoiceLineEvent(InvoiceLine invoiceLine, InvoiceLineAuditEvent.Action eventAction, Map<String, String> okapiHeaders) {
+    var event = getAuditEvent(invoiceLine, eventAction);
     log.info("sendInvoiceLineEvent:: Sending event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId());
     return sendToKafka(EventTopic.ACQ_INVOICE_LINE_CHANGED, event.getInvoiceLineId(), event, okapiHeaders)
       .onFailure(t -> log.warn("sendInvoiceLineEvent:: Failed to send event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId(), t));
@@ -95,4 +104,5 @@ public class AuditEventProducer {
   private String buildTopicName(String envId, String tenantId, String eventType) {
     return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(), tenantId, eventType);
   }
+
 }

--- a/src/main/java/org/folio/service/audit/AuditEventProducer.java
+++ b/src/main/java/org/folio/service/audit/AuditEventProducer.java
@@ -75,6 +75,7 @@ public class AuditEventProducer {
     return new InvoiceLineAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
+      .withInvoiceId(invoiceLine.getInvoiceId())
       .withInvoiceLineId(invoiceLine.getId())
       .withEventDate(new Date())
       .withActionDate(invoiceLine.getMetadata().getUpdatedDate())

--- a/src/main/java/org/folio/service/audit/AuditEventProducer.java
+++ b/src/main/java/org/folio/service/audit/AuditEventProducer.java
@@ -47,7 +47,7 @@ public class AuditEventProducer {
   public Future<Void> sendInvoiceLineEvent(InvoiceLine invoiceLine, InvoiceLineAuditEvent.Action action, Map<String, String> okapiHeaders) {
     var event = getAuditEvent(invoiceLine, action);
     log.info("sendInvoiceLineEvent:: Sending event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId());
-    return sendToKafka(EventTopic.ACQ_INVOICE_LINE_CHANGED, event.getInvoiceId(), event, okapiHeaders)
+    return sendToKafka(EventTopic.ACQ_INVOICE_LINE_CHANGED, event.getInvoiceLineId(), event, okapiHeaders)
       .onFailure(t -> log.warn("sendInvoiceLineEvent:: Failed to send event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId(), t));
   }
 
@@ -62,7 +62,7 @@ public class AuditEventProducer {
       .withInvoiceSnapshot(invoice.withMetadata(null));
   }
 
-  private InvoiceAuditEvent getAuditEvent(InvoiceLine invoiceLine, InvoiceLineAuditEvent.Action eventAction) {
+  private InvoiceLineAuditEvent getAuditEvent(InvoiceLine invoiceLine, InvoiceLineAuditEvent.Action eventAction) {
     return new InvoiceLineAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)

--- a/src/main/java/org/folio/service/audit/AuditEventProducer.java
+++ b/src/main/java/org/folio/service/audit/AuditEventProducer.java
@@ -94,6 +94,7 @@ public class AuditEventProducer {
 
     var producerManager = new SimpleKafkaProducerManager(Vertx.currentContext().owner(), kafkaConfig);
     KafkaProducer<String, String> producer = producerManager.createShared(topicName);
+    log.debug("sendToKafka:: Sending event for {} with id '{}' to kafka topic '{}' with url: '{}'", eventTopic, key, topicName, kafkaConfig.getKafkaUrl());
     return producer.send(kafkaProducerRecord)
       .onComplete(reply -> producer.end(ear -> producer.close()))
       .onSuccess(s -> log.info("sendToKafka:: Event for {} with id '{}' has been sent to kafka topic '{}'", eventTopic, key, topicName))

--- a/src/main/java/org/folio/service/audit/AuditEventProducer.java
+++ b/src/main/java/org/folio/service/audit/AuditEventProducer.java
@@ -1,0 +1,99 @@
+package org.folio.service.audit;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.SimpleKafkaProducerManager;
+import org.folio.kafka.services.KafkaProducerRecordBuilder;
+import org.folio.rest.jaxrs.model.EventAction;
+import org.folio.rest.jaxrs.model.EventTopic;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceAuditEvent;
+import org.folio.rest.jaxrs.model.InvoiceLineAuditEvent;
+import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.rest.tools.utils.TenantTool;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+public class AuditEventProducer {
+
+  private final KafkaConfig kafkaConfig;
+
+  /**
+   * Sends event for order change(Create, Edit, Delete) to kafka.
+   * OrderId is used as partition key to send all events for particular order to the same partition.
+   *
+   * @param order        the event payload
+   * @param eventAction  the event action
+   * @param okapiHeaders the okapi headers
+   * @return future with true if sending was success or failed future in another case
+   */
+  public Future<Void> sendInvoiceEvent(Invoice invoice, EventAction eventAction, Map<String, String> okapiHeaders) {
+    var event = getAuditEvent(invoice, eventAction);
+    log.info("sendInvoiceEvent:: Sending event with id: {} and invoiceId: {} to Kafka", event.getId(), invoice.getId());
+    return sendToKafka(EventTopic.ACQ_INVOICE_CHANGED, event.getInvoiceId(), event, okapiHeaders)
+      .onFailure(t -> log.warn("sendInvoiceEvent:: Failed to send event with id: {} and invoiceId: {} to Kafka", event.getId(), invoice.getId(), t));
+  }
+
+  public Future<Void> sendInvoiceLineEvent(InvoiceLine invoiceLine, EventAction action, Map<String, String> okapiHeaders) {
+    var event = getAuditEvent(invoiceLine, action);
+    log.info("sendInvoiceLineEvent:: Sending event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId());
+    return sendToKafka(EventTopic.ACQ_INVOICE_LINE_CHANGED, event.getInvoiceId(), event, okapiHeaders)
+      .onFailure(t -> log.warn("sendInvoiceLineEvent:: Failed to send event with id: {} and invoiceLineId: {} to Kafka", event.getId(), invoiceLine.getId(), t));
+  }
+
+  private InvoiceAuditEvent getAuditEvent(Invoice invoice, EventAction eventAction) {
+    return new InvoiceAuditEvent()
+      .withId(UUID.randomUUID().toString())
+      .withAction(eventAction)
+      .withInvoiceId(invoice.getId())
+      .withEventDate(new Date())
+      .withActionDate(invoice.getMetadata().getUpdatedDate())
+      .withUserId(invoice.getMetadata().getUpdatedByUserId())
+      .withInvoiceSnapshot(invoice.withMetadata(null));
+  }
+
+  private InvoiceAuditEvent getAuditEvent(InvoiceLine invoiceLine, EventAction eventAction) {
+    return new InvoiceLineAuditEvent()
+      .withId(UUID.randomUUID().toString())
+      .withAction(eventAction)
+      .withInvoiceId(invoiceLine.getId())
+      .withEventDate(new Date())
+      .withActionDate(invoiceLine.getMetadata().getUpdatedDate())
+      .withUserId(invoiceLine.getMetadata().getUpdatedByUserId())
+      .withInvoiceSnapshot(invoiceLine.withMetadata(null));
+  }
+
+  private Future<Void> sendToKafka(EventTopic eventTopic, String key, Object eventPayload, Map<String, String> okapiHeaders) {
+    var tenantId = TenantTool.tenantId(okapiHeaders);
+    var topicName = buildTopicName(kafkaConfig.getEnvId(), tenantId, eventTopic.value());
+    KafkaProducerRecord<String, String> kafkaProducerRecord = new KafkaProducerRecordBuilder<String, Object>(tenantId)
+      .key(key)
+      .value(eventPayload)
+      .topic(topicName)
+      .propagateOkapiHeaders(okapiHeaders)
+      .build();
+
+    var producerManager = new SimpleKafkaProducerManager(Vertx.currentContext().owner(), kafkaConfig);
+    KafkaProducer<String, String> producer = producerManager.createShared(topicName);
+    return producer.send(kafkaProducerRecord)
+      .onComplete(reply -> producer.end(ear -> producer.close()))
+      .onSuccess(s -> log.info("sendToKafka:: Event for {} with id '{}' has been sent to kafka topic '{}'", eventTopic, key, topicName))
+      .onFailure(t -> log.error("Failed to send event for {} with id '{}' to kafka topic '{}'", eventTopic, key, topicName, t))
+      .mapEmpty();
+  }
+
+  private String buildTopicName(String envId, String tenantId, String eventType) {
+    return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(), tenantId, eventType);
+  }
+}

--- a/src/main/java/org/folio/service/audit/AuditOutboxService.java
+++ b/src/main/java/org/folio/service/audit/AuditOutboxService.java
@@ -1,0 +1,109 @@
+package org.folio.service.audit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.folio.dao.audit.AuditOutboxEventLogDAO;
+import org.folio.dao.lock.InternalLockDAO;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.jaxrs.model.EventAction;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.rest.jaxrs.model.OutboxEventLog;
+import org.folio.rest.jaxrs.model.OutboxEventLog.EntityType;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.DBClient;
+import org.folio.rest.tools.utils.TenantTool;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+public class AuditOutboxService {
+
+  private static final String OUTBOX_LOCK_NAME = "audit_outbox";
+
+  private final AuditOutboxEventLogDAO outboxEventLogDAO;
+  private final InternalLockDAO internalLockDAO;
+  private final AuditEventProducer producer;
+
+  /**
+   * Reads outbox event logs from DB and send them to Kafka and delete from outbox table in a single transaction.
+   *
+   * @param okapiHeaders the okapi headers
+   * @param vertxContext the vertx context
+   * @return future with integer how many records have been processed
+   */
+  public Future<Integer> processOutboxEventLogs(Map<String, String> okapiHeaders, Context vertxContext) {
+    var tenantId = TenantTool.tenantId(okapiHeaders);
+    return new DBClient(vertxContext, okapiHeaders).getPgClient()
+      .withTrans(conn -> internalLockDAO.selectWithLocking(conn, OUTBOX_LOCK_NAME, tenantId)
+      .compose(retrievedCount -> outboxEventLogDAO.getEventLogs(conn, tenantId))
+      .compose(logs -> {
+        if (CollectionUtils.isEmpty(logs)) {
+          log.info("processOutboxEventLogs: No logs found in outbox table");
+          return Future.succeededFuture(0);
+        }
+        log.info("processOutboxEventLogs: {} logs found in outbox table, sending to kafka", logs.size());
+        return GenericCompositeFuture.join(sendEventLogsToKafka(logs, okapiHeaders))
+          .map(logs.stream().map(OutboxEventLog::getEventId).toList())
+          .compose(eventIds -> outboxEventLogDAO.deleteEventLogs(conn, eventIds, tenantId))
+          .onSuccess(count -> log.info("processOutboxEventLogs:: {} logs have been deleted from outbox table", count))
+          .onFailure(ex -> log.error("Logs deletion failed", ex));
+      })
+    );
+  }
+
+  private List<Future<Void>> sendEventLogsToKafka(List<OutboxEventLog> eventLogs, Map<String, String> okapiHeaders) {
+    return eventLogs.stream().map(eventLog ->
+      switch (eventLog.getEntityType()) {
+        case INVOICE -> producer.sendInvoiceEvent(Json.decodeValue(eventLog.getPayload(), Invoice.class), eventLog.getAction(), okapiHeaders);
+        case INVOICE_LINE -> producer.sendInvoiceLineEvent(Json.decodeValue(eventLog.getPayload(), InvoiceLine.class), eventLog.getAction(), okapiHeaders);
+      }).toList();
+  }
+
+  /**
+   * Saves invoice outbox log.
+   *
+   * @param conn         connection in transaction
+   * @param entity       the invoice
+   * @param action       the event action
+   * @param okapiHeaders okapi headers
+   * @return future with saved outbox log id in the same transaction
+   */
+  public Future<String> saveInvoiceOutboxLog(Conn conn, Invoice entity, EventAction action, Map<String, String> okapiHeaders) {
+    return saveOutboxLog(conn, okapiHeaders, action, EntityType.INVOICE, entity.getId(), entity);
+  }
+
+  /**
+   * Saves invoice line outbox log.
+   *
+   * @param conn         connection in transaction
+   * @param entity       the invoice line
+   * @param action       the event action
+   * @param okapiHeaders okapi headers
+   * @return future with saved outbox log id in the same transaction
+   */
+  public Future<String> saveInvoiceLineOutboxLog(Conn conn, InvoiceLine entity, EventAction action, Map<String, String> okapiHeaders) {
+    return saveOutboxLog(conn, okapiHeaders, action, EntityType.INVOICE_LINE, entity.getId(), entity);
+  }
+
+  private Future<String> saveOutboxLog(Conn conn, Map<String, String> okapiHeaders, EventAction action, EntityType entityType, String entityId, Object entity) {
+    log.debug("saveOutboxLog:: Saving outbox log for {} with id: {}", entityType, entityId);
+    var eventLog = new OutboxEventLog()
+      .withEventId(UUID.randomUUID().toString())
+      .withAction(action)
+      .withEntityType(entityType)
+      .withPayload(Json.encode(entity));
+    return outboxEventLogDAO.saveEventLog(conn, eventLog, TenantTool.tenantId(okapiHeaders))
+      .onSuccess(reply -> log.info("saveOutboxLog:: Outbox log has been saved for {} with id: {}", entityType, entityId))
+      .onFailure(e -> log.warn("saveOutboxLog:: Could not save outbox audit log for {} with id: {}", entityType, entityId, e));
+  }
+
+}

--- a/src/main/java/org/folio/service/util/OutboxEventFields.java
+++ b/src/main/java/org/folio/service/util/OutboxEventFields.java
@@ -1,0 +1,17 @@
+package org.folio.service.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OutboxEventFields {
+
+  EVENT_ID("event_id"),
+  ENTITY_TYPE("entity_type"),
+  ACTION("action"),
+  PAYLOAD("payload");
+
+  private final String name;
+
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -84,6 +84,16 @@
       "run": "after",
       "snippetPath": "invoices_table.sql",
       "fromModuleVersion": "mod-invoice-storage-5.9.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "tables/create_audit_outbox_table.sql",
+      "fromModuleVersion": "mod-invoice-storage-5.9.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "tables/create_internal_lock_table.sql",
+      "fromModuleVersion": "mod-invoice-storage-5.9.0"
     }
   ],
   "tables": [

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -88,12 +88,12 @@
     {
       "run": "after",
       "snippetPath": "tables/create_audit_outbox_table.sql",
-      "fromModuleVersion": "mod-invoice-storage-5.9.0"
+      "fromModuleVersion": "mod-invoice-storage-6.0.0"
     },
     {
       "run": "after",
       "snippetPath": "tables/create_internal_lock_table.sql",
-      "fromModuleVersion": "mod-invoice-storage-5.9.0"
+      "fromModuleVersion": "mod-invoice-storage-6.0.0"
     }
   ],
   "tables": [

--- a/src/main/resources/templates/db_scripts/tables/create_audit_outbox_table.sql
+++ b/src/main/resources/templates/db_scripts/tables/create_audit_outbox_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS outbox_event_log (
+  event_id uuid NOT NULL PRIMARY KEY,
+  entity_type text NOT NULL,
+  action text NOT NULL,
+  payload jsonb
+);

--- a/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
+++ b/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS internal_lock (
+  lock_name text NOT NULL PRIMARY KEY
+);
+
+INSERT INTO internal_lock(lock_name) VALUES ('audit_outbox') ON CONFLICT DO NOTHING;

--- a/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
@@ -7,8 +7,6 @@ import java.net.MalformedURLException;
 
 import org.junit.jupiter.api.Test;
 
-import io.restassured.http.ContentType;
-
 public class AuditOutboxAPITest extends TestBase {
 
   public static final String AUDIT_OUTBOX_ENDPOINT = "/invoice-storage/audit-outbox/process";

--- a/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
@@ -22,7 +22,6 @@ public class AuditOutboxAPITest extends TestBase {
       .then()
       .assertThat()
       .statusCode(200)
-      .contentType(ContentType.JSON)
       .extract()
       .response();
   }

--- a/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AuditOutboxAPITest.java
@@ -1,0 +1,30 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+
+import java.net.MalformedURLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
+
+public class AuditOutboxAPITest extends TestBase {
+
+  public static final String AUDIT_OUTBOX_ENDPOINT = "/invoice-storage/audit-outbox/process";
+
+  @Test
+  void testPostInvoiceStorageAuditOutboxProcess() throws MalformedURLException {
+    given()
+      .spec(commonRequestSpec())
+      .when()
+      .post(storageUrl(AUDIT_OUTBOX_ENDPOINT))
+      .then()
+      .assertThat()
+      .statusCode(200)
+      .contentType(ContentType.JSON)
+      .extract()
+      .response();
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -20,6 +20,10 @@ import io.vertx.core.json.JsonObject;
 class EntitiesCrudTest extends TestBase {
 
   private static final Logger log = LogManager.getLogger(EntitiesCrudTest.class);
+
+  private static final String CREATE_EVENT = "CREATE";
+  private static final String UPDATE_EVENT = "EDIT";
+
   private String sample = null;
 
   static Stream<TestEntities> deleteOrder() {
@@ -83,7 +87,7 @@ class EntitiesCrudTest extends TestBase {
   void testVerifyCollectionQuantity(TestEntities testEntity) throws MalformedURLException {
     log.info(String.format("--- mod-invoice-storage %s test: Verifying only 1 adjustment was created ... ", testEntity.name()));
     verifyCollectionQuantity(testEntity.getEndpoint(), TestEntities.BATCH_GROUP.equals(testEntity)? 2 : 1);
-
+    verifyKafkaMessagesSentIfNeeded(CREATE_EVENT, testEntity, TENANT_HEADER.getValue(), USER_ID_HEADER.getValue(), 1);
   }
 
   @ParameterizedTest
@@ -119,6 +123,7 @@ class EntitiesCrudTest extends TestBase {
     log.info(String.format("--- mod-invoice-storage %s test: Fetching updated %s with ID: %s", testEntity.name(),
         testEntity.name(), testEntity.getId()));
     testFetchingUpdatedEntity(testEntity.getId(), testEntity);
+    verifyKafkaMessagesSentIfNeeded(UPDATE_EVENT, testEntity, TENANT_HEADER.getValue(), USER_ID_HEADER.getValue(), 1);
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -1,10 +1,10 @@
 package org.folio.rest.impl;
 
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
 import static org.folio.rest.impl.TestBase.TENANT_HEADER;
 import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -36,6 +36,7 @@ import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.json.JsonObject;
+import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
 
 public class StorageTestSuite {
   private static final Logger log = LogManager.getLogger(StorageTestSuite.class);
@@ -44,6 +45,14 @@ public class StorageTestSuite {
   private static final int port = NetworkUtils.nextFreePort();
   public static final Header URL_TO_HEADER = new Header("X-Okapi-Url-to", "http://localhost:" + port);
   private static TenantJob tenantJob;
+  public static EmbeddedKafkaCluster kafkaCluster;
+  public static final String KAFKA_ENV_VALUE = "test-env";
+  private static final String KAFKA_HOST = "KAFKA_HOST";
+  private static final String KAFKA_PORT = "KAFKA_PORT";
+  private static final String KAFKA_ENV = "ENV";
+  private static final String OKAPI_URL_KEY = "OKAPI_URL";
+  public static final int mockPort = NetworkUtils.nextFreePort();
+
 
   private StorageTestSuite() {}
 
@@ -83,15 +92,25 @@ public class StorageTestSuite {
   }
 
   @BeforeAll
-  public static void before() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  public static void before() throws InterruptedException, ExecutionException, TimeoutException {
     // tests expect English error messages only, no Danish/German/...
     Locale.setDefault(Locale.US);
 
     vertx = Vertx.vertx();
 
-    log.info("Start container database");
+    log.info("Starting kafka cluster");
+    kafkaCluster = EmbeddedKafkaCluster.provisionWith(defaultClusterConfig());
+    kafkaCluster.start();
+    String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
+    System.setProperty(KAFKA_HOST, hostAndPort[0]);
+    System.setProperty(KAFKA_PORT, hostAndPort[1]);
+    System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
+    System.setProperty(OKAPI_URL_KEY, "http://localhost:" + mockPort);
+    log.info("Kafka cluster started with broker list: {}", kafkaCluster.getBrokerList());
 
+    log.info("Starting container database");
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
+
 
     DeploymentOptions options = new DeploymentOptions();
 
@@ -106,6 +125,7 @@ public class StorageTestSuite {
   @AfterAll
   public static void after() throws InterruptedException, ExecutionException, TimeoutException {
     log.info("Delete tenant");
+    kafkaCluster.stop();
     deleteTenant(tenantJob, TENANT_HEADER);
 
     CompletableFuture<String> undeploymentComplete = new CompletableFuture<>();

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -45,13 +45,14 @@ public class StorageTestSuite {
   private static final int port = NetworkUtils.nextFreePort();
   public static final Header URL_TO_HEADER = new Header("X-Okapi-Url-to", "http://localhost:" + port);
   private static TenantJob tenantJob;
-  public static EmbeddedKafkaCluster kafkaCluster;
+
+  public static EmbeddedKafkaCluster KAFKA_CLUSTER;
   public static final String KAFKA_ENV_VALUE = "test-env";
   private static final String KAFKA_HOST = "KAFKA_HOST";
   private static final String KAFKA_PORT = "KAFKA_PORT";
   private static final String KAFKA_ENV = "ENV";
   private static final String OKAPI_URL_KEY = "OKAPI_URL";
-  public static final int mockPort = NetworkUtils.nextFreePort();
+  public static final int MOCK_KAFKA_PORT = NetworkUtils.nextFreePort();
 
 
   private StorageTestSuite() {}
@@ -99,14 +100,14 @@ public class StorageTestSuite {
     vertx = Vertx.vertx();
 
     log.info("Starting kafka cluster");
-    kafkaCluster = EmbeddedKafkaCluster.provisionWith(defaultClusterConfig());
-    kafkaCluster.start();
-    String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
+    KAFKA_CLUSTER = EmbeddedKafkaCluster.provisionWith(defaultClusterConfig());
+    KAFKA_CLUSTER.start();
+    String[] hostAndPort = KAFKA_CLUSTER.getBrokerList().split(":");
     System.setProperty(KAFKA_HOST, hostAndPort[0]);
     System.setProperty(KAFKA_PORT, hostAndPort[1]);
     System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
-    System.setProperty(OKAPI_URL_KEY, "http://localhost:" + mockPort);
-    log.info("Kafka cluster started with broker list: {}", kafkaCluster.getBrokerList());
+    System.setProperty(OKAPI_URL_KEY, "http://localhost:" + MOCK_KAFKA_PORT);
+    log.info("Kafka cluster started with broker list: {}", KAFKA_CLUSTER.getBrokerList());
 
     log.info("Starting container database");
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
@@ -122,7 +123,7 @@ public class StorageTestSuite {
   @AfterAll
   public static void after() throws InterruptedException, ExecutionException, TimeoutException {
     log.info("Delete tenant");
-    kafkaCluster.stop();
+    KAFKA_CLUSTER.stop();
     deleteTenant(tenantJob, TENANT_HEADER);
 
     CompletableFuture<String> undeploymentComplete = new CompletableFuture<>();

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -170,4 +170,6 @@ public class StorageTestSuite {
   class VoucherNumberTestNested extends VoucherNumberTest {}
   @Nested
   class OrderStorageServiceTestNested extends OrderStorageServiceTest {}
+  @Nested
+  class AuditOutboxAPITestNested extends AuditOutboxAPITest {}
 }

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -111,12 +111,9 @@ public class StorageTestSuite {
     log.info("Starting container database");
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
-
     DeploymentOptions options = new DeploymentOptions();
-
     options.setConfig(new JsonObject().put("http.port", port));
     options.setWorker(true);
-
     startVerticle(options);
 
     tenantJob = prepareTenant(TENANT_HEADER, false, false);


### PR DESCRIPTION
## Purpose
[[MODINVOSTO-187] Implement audit outbox pattern for sending kafka events about invoice updates](https://folio-org.atlassian.net/browse/MODINVOSTO-187)
[[MODINVOSTO-188] Implement audit outbox pattern for sending kafka events about invoice line updates](https://folio-org.atlassian.net/browse/MODINVOSTO-188)


## Approach
- Refactor existing invoice and invoice line services and DAOs to use Conn instead of PgUtil
- Add new tables for outbox event logs and internal locks
- Add DAOs for logs and locks
- Add Audit outbox service for storing updates as logs
- Add Audit outbox producer for sending logs to kafka
- Add new API for _timer interface to trigger producer message processing
- Add kafka dependencies
- Add new API test to get full coverage

## Verification:
### After enabling module, the new tables are created:
![image](https://github.com/user-attachments/assets/6c455a84-e7d5-4d4c-908f-f10f4b6f1fa8)
![image](https://github.com/user-attachments/assets/55ec6eed-0be9-4a53-aa45-4bcf8512d233)

### After creating invoice and invoice line the outbox events are stored:
![image](https://github.com/user-attachments/assets/2beffa04-bb68-447c-986c-0b0eb3bbd3c4)

### Sending logs to kafka:
![image](https://github.com/user-attachments/assets/36f34f2c-c078-45a2-99f4-fa1682b826d8)
![image](https://github.com/user-attachments/assets/047b3fb8-e8a5-4c9e-864d-5e7025001944)
![image](https://github.com/user-attachments/assets/61d2b564-7dd6-47ab-b001-9ac27aca2914)

## Integration tests:
![image](https://github.com/user-attachments/assets/9179b391-be08-43ac-9c5b-83df91e6b596)
