### PR TITLE
[MODINVOICE-647] Updated models + new migration

### DIFF
--- a/src/main/resources/templates/db_scripts/data-migration/7.0.0/fill_missing_next_il_number.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/7.0.0/fill_missing_next_il_number.ftl
@@ -1,0 +1,14 @@
+<#if mode.name() == "UPDATE">
+  WITH missing_next_numbers AS (
+    SELECT invoice.id, COALESCE(MAX((il.jsonb ->> 'invoiceLineNumber')::int), 0) + 1 AS number
+      FROM ${myuniversity}_${mymodule}.invoices invoice
+      LEFT JOIN ${myuniversity}_${mymodule}.invoice_lines il ON il.invoiceId = invoice.id
+      WHERE invoice.jsonb -> 'nextInvoiceLineNumber' IS NULL
+      GROUP BY invoice.id
+  )
+
+  UPDATE ${myuniversity}_${mymodule}.invoices invoice
+  SET jsonb = jsonb_set(invoice.jsonb, '{nextInvoiceLineNumber}', to_jsonb(mnn.number))
+  FROM missing_next_numbers mnn
+  WHERE invoice.id = mnn.id;
+</#if>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -94,6 +94,11 @@
       "run": "after",
       "snippetPath": "data-migration/6.1.0/drop_internal_lock_table.ftl",
       "fromModuleVersion": "mod-invoice-storage-6.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/7.0.0/fill_missing_next_il_number.ftl",
+      "fromModuleVersion": "mod-invoice-storage-7.0.0"
     }
   ],
   "tables": [


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
- Updated model removing the readonly attribute for `nextInvoiceLineNumber`
- Added a migration to calculate missing next numbers from lines

## Related PRs
- [acq-models 1](https://github.com/folio-org/acq-models/pull/567), [acq-models 2](https://github.com/folio-org/acq-models/pull/568)
- [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/623)
- [mod-invoice](https://github.com/folio-org/mod-invoice/pull/622)
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1307)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2352)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
