### PR TITLE
Trillium 6.1.1 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-## 6.1.0 - Released (Trillium R1 2025)
+## 6.1.0 - Released (Trillium R1 2026 Bug Fix)
+The primary focus of this release was to fix issues with readonly properties inside acq models schema.
+
+[Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v6.0.0...v6.1.0)
+
+### Bug Fixes
+* [MODINVOICE-648](https://folio-org.atlassian.net/browse/MODINVOICE-648) - "Sub total" and "Calculated total amount" missing from Invoice version history
+* [MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion
+
+## 6.1.0 - Released (Trillium R1 2026)
 The primary focus of this release was to upgrade to Vert.x 5.0, implement invoice adjustments API, improve locking mechanism and migrate settings.
 
 [Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v6.0.0...v6.1.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-## 6.1.0 - Released (Trillium R1 2026 Bug Fix)
+## 6.1.1 - Released (Trillium R1 2026 Bug Fix)
 The primary focus of this release was to fix issues with readonly properties inside acq models schema.
 
-[Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v6.0.0...v6.1.0)
+[Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v6.1.0...v6.1.1)
 
 ### Bug Fixes
 * [MODINVOICE-648](https://folio-org.atlassian.net/browse/MODINVOICE-648) - "Sub total" and "Calculated total amount" missing from Invoice version history

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-invoice-storage</artifactId>
-  <version>6.1.1</version>
+  <version>6.1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -581,7 +581,7 @@
     <url>https://github.com/folio-org/mod-invoice-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-invoice-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-invoice-storage.git</developerConnection>
-    <tag>v6.1.1</tag>
+    <tag>v6.1.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-invoice-storage</artifactId>
-  <version>6.1.1-SNAPSHOT</version>
+  <version>6.1.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -581,7 +581,7 @@
     <url>https://github.com/folio-org/mod-invoice-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-invoice-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-invoice-storage.git</developerConnection>
-    <tag>v6.1.0</tag>
+    <tag>v6.1.1</tag>
   </scm>
 
 </project>

--- a/src/main/resources/templates/db_scripts/data-migration/7.0.0/fill_missing_next_il_number.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/7.0.0/fill_missing_next_il_number.ftl
@@ -1,0 +1,14 @@
+<#if mode.name() == "UPDATE">
+  WITH missing_next_numbers AS (
+    SELECT invoice.id, COALESCE(MAX((il.jsonb ->> 'invoiceLineNumber')::int), 0) + 1 AS number
+      FROM ${myuniversity}_${mymodule}.invoices invoice
+      LEFT JOIN ${myuniversity}_${mymodule}.invoice_lines il ON il.invoiceId = invoice.id
+      WHERE invoice.jsonb -> 'nextInvoiceLineNumber' IS NULL
+      GROUP BY invoice.id
+  )
+
+  UPDATE ${myuniversity}_${mymodule}.invoices invoice
+  SET jsonb = jsonb_set(invoice.jsonb, '{nextInvoiceLineNumber}', to_jsonb(mnn.number))
+  FROM missing_next_numbers mnn
+  WHERE invoice.id = mnn.id;
+</#if>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -94,6 +94,11 @@
       "run": "after",
       "snippetPath": "data-migration/6.1.0/drop_internal_lock_table.ftl",
       "fromModuleVersion": "mod-invoice-storage-6.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/7.0.0/fill_missing_next_il_number.ftl",
+      "fromModuleVersion": "mod-invoice-storage-7.0.0"
     }
   ],
   "tables": [

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -98,7 +98,7 @@
     {
       "run": "after",
       "snippetPath": "data-migration/7.0.0/fill_missing_next_il_number.ftl",
-      "fromModuleVersion": "mod-invoice-storage-7.0.0"
+      "fromModuleVersion": "mod-invoice-storage-6.1.1"
     }
   ],
   "tables": [


### PR DESCRIPTION
## 6.1.1 - Released (Trillium R1 2026 Bug Fix)
The primary focus of this release was to fix issues with readonly properties inside acq models schema.

[Full Changelog](https://github.com/folio-org/mod-invoice-storage/compare/v6.1.0...v6.1.1)

### Bug Fixes
* [MODINVOICE-648](https://folio-org.atlassian.net/browse/MODINVOICE-648) - "Sub total" and "Calculated total amount" missing from Invoice version history
* [MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion